### PR TITLE
Do not try to load/store out of bound Multisets - allow to store (almost) arbitrarily sized types in dvid - bug fixes

### DIFF
--- a/src/main/java/bdv/bigcat/BigCat.java
+++ b/src/main/java/bdv/bigcat/BigCat.java
@@ -53,13 +53,13 @@ public class BigCat
 	public static void main( final String[] args ) throws JsonSyntaxException, JsonIOException, IOException
 	{
 		final String url = "http://vm570.int.janelia.org:8080";
-		final String labelsBase = "multisets-labels-downscaled";
+		final String labelsBase = "multisets-labels-downscaled-zero-extended-2"; //"multisets-labels-downscaled";
 		final String uuid = "4668221206e047648f622dc4690ff7dc";
 
 		final Server server = new Server( url );
 		final Repository repo = new Repository( server, uuid );
 
-		final DatasetKeyValue[] stores = new DatasetKeyValue[ 3 ];
+		final DatasetKeyValue[] stores = new DatasetKeyValue[ 4 ];
 
 		for ( int i = 0; i < stores.length; ++i )
 		{
@@ -79,7 +79,8 @@ public class BigCat
 				{ 1, 1, 1 },
 				{ 2, 2, 2 },
 				{ 4, 4, 4 },
-				{ 8, 8, 8 } };
+				{ 8, 8, 8 },
+				{16, 16, 16 } };
 
 		try
 		{

--- a/src/main/java/bdv/bigcat/BigCat.java
+++ b/src/main/java/bdv/bigcat/BigCat.java
@@ -53,8 +53,8 @@ public class BigCat
 	public static void main( final String[] args ) throws JsonSyntaxException, JsonIOException, IOException
 	{
 		final String url = "http://vm570.int.janelia.org:8080";
-		final String labelsBase = "multisets-labels5";
-		final String uuid = "c223287b023544aa9968be56a81fab34";
+		final String labelsBase = "multisets-labels-downscaled";
+		final String uuid = "4668221206e047648f622dc4690ff7dc";
 
 		final Server server = new Server( url );
 		final Repository repo = new Repository( server, uuid );

--- a/src/main/java/bdv/bigcat/BigCatMultisetLabels.java
+++ b/src/main/java/bdv/bigcat/BigCatMultisetLabels.java
@@ -44,9 +44,9 @@ public class BigCatMultisetLabels
 		
 		String url = "http://vm570.int.janelia.org:8080";
 		String apiUrl = url + "/api";
-		String uuid = "c223287b023544aa9968be56a81fab34";
+		String uuid = "4668221206e047648f622dc4690ff7dc";
 		String raw = "multisets-raw5";
-		String labels = "multisets-labels5";
+		String labels = "multisets-labels-downscaled";
 		
 		String url2 = "http://emrecon100.janelia.priv";
 		String apiUrl2 = url2 + "/api";

--- a/src/main/java/bdv/bigcat/BigCatMultisetsMinimal.java
+++ b/src/main/java/bdv/bigcat/BigCatMultisetsMinimal.java
@@ -1,0 +1,172 @@
+package bdv.bigcat;
+
+import static bdv.bigcat.CombinedImgLoader.SetupIdAndLoader.setupIdAndLoader;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.xml.ws.http.HTTPException;
+
+import com.google.gson.JsonIOException;
+import com.google.gson.JsonSyntaxException;
+
+import bdv.BigDataViewer;
+import bdv.bigcat.composite.ARGBCompositeAlphaYCbCr;
+import bdv.bigcat.composite.Composite;
+import bdv.bigcat.composite.CompositeCopy;
+import bdv.bigcat.composite.CompositeProjector;
+import bdv.bigcat.ui.ARGBConvertedLabelsSource;
+import bdv.bigcat.ui.RandomSaturatedARGBStream;
+import bdv.img.cache.Cache;
+import bdv.img.dvid.DvidGrayscale8ImageLoader;
+import bdv.labels.labelset.DvidLabels64MultisetSetupImageLoader;
+import bdv.spimdata.SequenceDescriptionMinimal;
+import bdv.spimdata.SpimDataMinimal;
+import bdv.tools.brightness.ConverterSetup;
+import bdv.tools.brightness.RealARGBColorConverterSetup;
+import bdv.util.dvid.DatasetKeyValue;
+import bdv.util.dvid.Repository;
+import bdv.util.dvid.Server;
+import bdv.viewer.DisplayMode;
+import bdv.viewer.Source;
+import bdv.viewer.SourceAndConverter;
+import bdv.viewer.ViewerOptions;
+import bdv.viewer.render.AccumulateProjectorFactory;
+import mpicbg.spim.data.generic.sequence.BasicViewSetup;
+import mpicbg.spim.data.registration.ViewRegistration;
+import mpicbg.spim.data.registration.ViewRegistrations;
+import mpicbg.spim.data.sequence.TimePoint;
+import mpicbg.spim.data.sequence.TimePoints;
+import net.imglib2.display.ScaledARGBConverter;
+import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.type.numeric.ARGBType;
+import net.imglib2.type.volatiles.VolatileARGBType;
+
+public class BigCatMultisetsMinimal
+{
+	public static void main( final String[] args ) throws JsonSyntaxException, JsonIOException, IOException
+	{
+		final String url = "http://vm570.int.janelia.org:8080";
+		final String labelsBase = "multisets-labels-downscaled";
+		final String uuid = "4668221206e047648f622dc4690ff7dc";
+
+		final Server server = new Server( url );
+		final Repository repo = new Repository( server, uuid );
+
+		final DatasetKeyValue[] stores = new DatasetKeyValue[ 3 ];
+
+		for ( int i = 0; i < stores.length; ++i )
+		{
+			stores[ i ] = new DatasetKeyValue( repo.getRootNode(), labelsBase + "-" + ( 1 << ( i + 1 ) ) );
+
+			try
+			{
+				repo.getRootNode().createDataset( stores[ i ].getName(), DatasetKeyValue.TYPE );
+			}
+			catch ( final HTTPException e )
+			{
+				e.printStackTrace( System.err );
+			}
+		}
+
+		final double[][] resolutions = new double[][]{
+				{ 1, 1, 1 },
+				{ 2, 2, 2 },
+				{ 4, 4, 4 },
+				{ 8, 8, 8 } };
+
+		try
+		{
+			System.setProperty( "apple.laf.useScreenMenuBar", "true" );
+
+			/* data sources */
+			final DvidGrayscale8ImageLoader dvidGrayscale8ImageLoader = new DvidGrayscale8ImageLoader(
+					"http://emrecon100.janelia.priv/api",
+					"2a3fd320aef011e4b0ce18037320227c",
+					"grayscale" );
+			final DvidLabels64MultisetSetupImageLoader dvidLabelsMultisetImageLoader = new DvidLabels64MultisetSetupImageLoader(
+					1,
+					"http://emrecon100.janelia.priv/api",
+					"2a3fd320aef011e4b0ce18037320227c",
+					"bodies",
+					resolutions,
+					stores );
+			
+			final CombinedImgLoader imgLoader = new CombinedImgLoader(
+					setupIdAndLoader( 0, dvidGrayscale8ImageLoader )
+					);
+			dvidGrayscale8ImageLoader.setCache( imgLoader.cache );
+			dvidLabelsMultisetImageLoader.setCache( imgLoader.cache );
+			
+			// convert labels into ARGB
+			final SegmentBodyAssignment assignment = new SegmentBodyAssignment();
+			final RandomSaturatedARGBStream colorStream = new RandomSaturatedARGBStream( assignment );
+			colorStream.setAlpha( 0x30 );
+			final ARGBConvertedLabelsSource convertedLabels =
+					new ARGBConvertedLabelsSource(
+							2,
+							dvidLabelsMultisetImageLoader,
+							colorStream );
+			
+			final ScaledARGBConverter.ARGB converter = new ScaledARGBConverter.ARGB( 0, 255 );
+			final ScaledARGBConverter.VolatileARGB vconverter = new ScaledARGBConverter.VolatileARGB( 0, 255 );
+			
+			final SourceAndConverter< VolatileARGBType > vsoc = 
+					new SourceAndConverter< VolatileARGBType >( convertedLabels, vconverter );
+			final SourceAndConverter< ARGBType > soc = 
+					new SourceAndConverter< ARGBType >( convertedLabels.nonVolatile(), converter, vsoc );
+
+			final TimePoints timepoints = new TimePoints( Arrays.asList( new TimePoint( 0 ) ) );
+			final Map< Integer, BasicViewSetup > setups = new HashMap< Integer, BasicViewSetup >();
+			setups.put( 0, new BasicViewSetup( 0, null, null, null ) );
+			final ViewRegistrations reg = new ViewRegistrations( Arrays.asList(
+					new ViewRegistration( 0, 0 ) ) );
+
+			final SequenceDescriptionMinimal seq = new SequenceDescriptionMinimal( timepoints, setups, imgLoader, null );
+			final SpimDataMinimal spimData = new SpimDataMinimal( null, seq, reg );
+
+			final ArrayList< ConverterSetup > converterSetups = new ArrayList< ConverterSetup >();
+			final ArrayList< SourceAndConverter< ? > > sources = new ArrayList< SourceAndConverter< ? > >();
+			
+			BigDataViewer.initSetups( spimData, converterSetups, sources );
+			
+			sources.add( soc );
+			converterSetups.add( new RealARGBColorConverterSetup( 2, converter, vconverter ) );
+			
+			/* composites */
+			final ArrayList< Composite< ARGBType, ARGBType > > composites = new ArrayList< Composite<ARGBType,ARGBType> >();
+			composites.add( new CompositeCopy< ARGBType >() );
+			composites.add( new ARGBCompositeAlphaYCbCr() );
+			final HashMap< Source< ? >, Composite< ARGBType, ARGBType > > sourceCompositesMap = new HashMap< Source< ? >, Composite< ARGBType, ARGBType > >();
+			sourceCompositesMap.put( sources.get( 0 ).getSpimSource(), composites.get( 0 ) );
+			sourceCompositesMap.put( sources.get( 1 ).getSpimSource(), composites.get( 1 ) );
+			final AccumulateProjectorFactory< ARGBType > projectorFactory = new CompositeProjector.CompositeProjectorFactory< ARGBType >( sourceCompositesMap );
+			
+			final Cache cache = imgLoader.getCache();
+			final String windowTitle = "bigcat";
+			final BigDataViewer bdv = new BigDataViewer( converterSetups, sources, null, timepoints.size(), cache, windowTitle, null,
+					ViewerOptions.options()
+						.accumulateProjectorFactory( projectorFactory ) // nicer accumulation of sources
+						// .accumulateProjectorFactory( AccumulateProjectorCompositeARGB.factory ) // not so nice accumulation
+						.numRenderingThreads( 16 ) );
+
+			// set initial view
+			final AffineTransform3D transform = new AffineTransform3D();
+			transform.set(
+					4.3135842398185575, -1.0275561336713027E-16, 1.1102230246251565E-16, -14207.918453952327,
+					-1.141729037412541E-17, 4.313584239818558, 1.0275561336713028E-16, -9482.518144778587,
+					1.1102230246251565E-16, -1.141729037412541E-17, 4.313584239818559, -17181.48737890195 );
+			bdv.getViewer().setCurrentViewerTransform( transform );
+			bdv.getViewer().setDisplayMode( DisplayMode.FUSED );
+
+			bdv.getViewerFrame().setVisible( true );
+		}
+		catch ( final Exception e )
+		{
+			e.printStackTrace();
+		}
+	}
+}

--- a/src/main/java/bdv/bigcat/Downscale.java
+++ b/src/main/java/bdv/bigcat/Downscale.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.util.Arrays;
 
-import javax.naming.spi.DirectoryManager;
 import javax.xml.ws.http.HTTPException;
 
 import bdv.img.cache.VolatileGlobalCellCache;
@@ -87,8 +86,8 @@ public class Downscale
 				
 				long[] currDim = new long[] {
 						( long ) ( dimensions[ 0 ] / currRes[ 0 ] ),
-						( long ) ( dimensions[ 0 ] / currRes[ 0 ] ),
-						( long ) ( dimensions[ 0 ] / currRes[ 0 ] )
+						( long ) ( dimensions[ 1 ] / currRes[ 1 ] ),
+						( long ) ( dimensions[ 2 ] / currRes[ 2 ] )
 				};
 				
 				long[] currPos = new long[ 3 ];

--- a/src/main/java/bdv/bigcat/Downscale.java
+++ b/src/main/java/bdv/bigcat/Downscale.java
@@ -47,7 +47,7 @@ public class Downscale
 				info.MaxPoint[ 1 ] + 1 - info.MinPoint[ 1 ],
 				info.MaxPoint[ 2 ] + 1 - info.MinPoint[ 2 ]
 		};
-		
+
 		DatasetKeyValue[] stores = new DatasetKeyValue[ 4 ];
 		double[][] resolutions = new double[stores.length + 1][];
 		
@@ -88,13 +88,13 @@ public class Downscale
 				
 				final ArrayList< long[] > positions = new ArrayList< long[] >();
 
-				for ( int x = 0; x < currDim[ 0 ]; x += blockSizes[ 0 ] )
+				for ( int x = 0; x * currRes[ 0 ] < dimensions[ 0 ]; x += blockSizes[ 0 ] )
 				{
 					currPos[ 0 ] = x;
-					for ( int y = 0; y < currDim[ 1 ]; y += blockSizes[ 1 ] )
+					for ( int y = 0; y * currRes[ 1 ]< dimensions[ 1 ]; y += blockSizes[ 1 ] )
 					{
 						currPos[ 1 ] = y;
-						for ( int z = 0; z < currDim[ 2 ]; z += blockSizes[ 2 ] )
+						for ( int z = 0; z * currRes[ 2 ] < dimensions[ 2 ]; z += blockSizes[ 2 ] )
 						{
 							currPos[ 2 ] = z;
 							positions.add( currPos.clone() );

--- a/src/main/java/bdv/bigcat/Downscale.java
+++ b/src/main/java/bdv/bigcat/Downscale.java
@@ -23,11 +23,11 @@ import bdv.util.dvid.Server;
 public class Downscale
 {
 	
-	public static void main( String[] args ) throws MalformedURLException, IOException
+	public static void main( String[] args ) throws MalformedURLException, IOException, InterruptedException
 	{
 		
 		final String url = "http://vm570.int.janelia.org:8080";
-		final String labelsBase = "multisets-labels-downscaled-zero-extended";
+		final String labelsBase = "multisets-labels-downscaled-zero-extended-2";
 		String uuid = "4668221206e047648f622dc4690ff7dc";
 		
 		Server server = new Server( url );
@@ -102,7 +102,7 @@ public class Downscale
 					}
 				}
 				ExecutorService tp = Executors.newFixedThreadPool( Runtime.getRuntime().availableProcessors() );
-				int elementsPerBatch = positions.size() / Runtime.getRuntime().availableProcessors();
+				int elementsPerBatch = Math.max( positions.size() / Runtime.getRuntime().availableProcessors(), 1 );
 				ArrayList< Callable< Void > > callables = new ArrayList< Callable< Void > >();
 				final int finalLevel = level;
 				for ( int b = 0; b < positions.size(); b += elementsPerBatch )
@@ -149,5 +149,6 @@ public class Downscale
 		{
 			ex.printStackTrace( System.err );
 		}
+		System.out.println( "Done." );
 	}
 }

--- a/src/main/java/bdv/bigcat/Downscale.java
+++ b/src/main/java/bdv/bigcat/Downscale.java
@@ -27,7 +27,7 @@ public class Downscale
 	{
 		
 		final String url = "http://vm570.int.janelia.org:8080";
-		final String labelsBase = "multisets-labels-downscaled";
+		final String labelsBase = "multisets-labels-downscaled-zero-extended";
 		String uuid = "4668221206e047648f622dc4690ff7dc";
 		
 		Server server = new Server( url );

--- a/src/main/java/bdv/bigcat/Downscale.java
+++ b/src/main/java/bdv/bigcat/Downscale.java
@@ -1,0 +1,126 @@
+package bdv.bigcat;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.util.Arrays;
+
+import javax.naming.spi.DirectoryManager;
+import javax.xml.ws.http.HTTPException;
+
+import bdv.img.cache.VolatileGlobalCellCache;
+import bdv.img.dvid.Labels64DataInstance;
+import bdv.img.dvid.Labels64DataInstance.Extended;
+import bdv.labels.labelset.DvidLabels64MultisetSetupImageLoader;
+import bdv.util.JsonHelper;
+import bdv.util.dvid.DatasetKeyValue;
+import bdv.util.dvid.Repository;
+import bdv.util.dvid.Server;
+
+public class Downscale
+{
+	
+	public static void main( String[] args ) throws MalformedURLException, IOException
+	{
+		
+		final String url = "http://vm570.int.janelia.org:8080";
+		final String labelsBase = "multisets-labels-downscaled";
+		String uuid = "4668221206e047648f622dc4690ff7dc";
+		
+		Server server = new Server( url );
+		Repository repo = new Repository( server, uuid );
+		
+		String baseUrl = "http://emrecon100.janelia.priv";
+		String baseApiUrl = baseUrl + "/api";
+		String baseUuid = "2a3fd320aef011e4b0ce18037320227c";
+		String baseName = "bodies";
+		
+		Extended info = ( (Labels64DataInstance)JsonHelper.fetch(
+				baseApiUrl + "/node/" + baseUuid + "/" + baseName + "/info",
+				Labels64DataInstance.class ) ).Extended;
+		
+		long[] dimensions = new long[] {
+				info.MaxPoint[ 0 ] + 1 - info.MinPoint[ 0 ],
+				info.MaxPoint[ 1 ] + 1 - info.MinPoint[ 1 ],
+				info.MaxPoint[ 2 ] + 1 - info.MinPoint[ 2 ]
+		};
+		
+		DatasetKeyValue[] stores = new DatasetKeyValue[ 4 ];
+		double[][] resolutions = new double[stores.length + 1][];
+		
+		int[] blockSizes = new int[] { 32, 32 ,32 };
+		
+		for ( int i = 0; i < resolutions.length; ++i )
+		{
+			int scale = 1 << i;
+			resolutions[ i ] = new double[] { scale, scale, scale };
+			if ( i == 0 ) continue;
+			stores[ i - 1 ] = new DatasetKeyValue( repo.getRootNode(), labelsBase + "-" + scale );
+			try {
+				repo.getRootNode().createDataset( stores[ i - 1 ].getName(), DatasetKeyValue.TYPE );
+			}
+			catch ( HTTPException e )
+			{
+//				e.printStackTrace();
+			}
+		}
+		
+		int nLevels = stores.length + 1;
+		
+		try
+		{
+			final DvidLabels64MultisetSetupImageLoader dvidLabelsMultisetImageLoader = 
+					new DvidLabels64MultisetSetupImageLoader(
+					1,
+					baseApiUrl,
+					baseUuid,
+					baseName,
+					resolutions,
+					stores );
+			
+			VolatileGlobalCellCache cache = new VolatileGlobalCellCache( 1, 1, nLevels, 10 );
+			
+			dvidLabelsMultisetImageLoader.setCache( cache );
+			
+			for ( int level = 1; level < nLevels; ++ level )
+			{
+				double[] currRes = resolutions[ level ];
+				
+				long[] currDim = new long[] {
+						( long ) ( dimensions[ 0 ] / currRes[ 0 ] ),
+						( long ) ( dimensions[ 0 ] / currRes[ 0 ] ),
+						( long ) ( dimensions[ 0 ] / currRes[ 0 ] )
+				};
+				
+				long[] currPos = new long[ 3 ];
+				
+				System.out.println( Arrays.toString(  currDim  ) + " " + Arrays.toString(  dimensions  ) );
+				
+				for ( int x = 0; x < currDim[ 0 ]; x += blockSizes[ 0 ] )
+				{
+					currPos[ 0 ] = x;
+					for ( int y = 0; y < currDim[ 1 ]; y += blockSizes[ 1 ] )
+					{
+						currPos[ 1 ] = y;
+						for ( int z = 0; z < currDim[ 2 ]; z += blockSizes[ 2 ] )
+						{
+							currPos[ 2 ] = z;
+							dvidLabelsMultisetImageLoader.downscaleLoader.loadArray( 
+									0, 
+									1, 
+									level, 
+									blockSizes, 
+									currPos
+									);
+						}
+					}
+				}
+				
+			}
+			
+		}
+		catch ( Exception ex )
+		{
+			ex.printStackTrace( System.err );
+		}
+	}
+}

--- a/src/main/java/bdv/img/dvid/AbstractDvidImageWriter.java
+++ b/src/main/java/bdv/img/dvid/AbstractDvidImageWriter.java
@@ -1,0 +1,256 @@
+package bdv.img.dvid;
+
+import java.io.IOException;
+
+import com.google.gson.JsonIOException;
+import com.google.gson.JsonSyntaxException;
+
+import bdv.util.BlockedInterval;
+import bdv.util.dvid.DatasetBlk;
+import bdv.util.dvid.DatasetBlkUint8;
+import net.imglib2.Cursor;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.type.numeric.NumericType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.view.IntervalView;
+import net.imglib2.view.Views;
+
+public class AbstractDvidImageWriter< T extends NumericType< T > >
+{
+	
+	protected final DatasetBlk< T > dataset;
+	
+	protected final int[] blockSize;
+
+	public AbstractDvidImageWriter( DatasetBlk< T > dataset, int[] blockSize )
+	{
+		this.dataset = dataset;
+		this.blockSize = blockSize;
+	}
+	
+	public AbstractDvidImageWriter( DatasetBlk< T > dataset ) throws JsonSyntaxException, JsonIOException, IOException
+	{
+		this( dataset, dataset.getBlockSize() );
+	}
+
+	/**
+	 * @param image
+	 *            Image to be stored in dvid server.
+	 * @param iterationAxis
+	 *            Along which axis to iterate.
+	 * @param steps
+	 *            Step sizes along each axis.
+	 * @param offset
+	 *            Offset target position by offset.
+	 * 
+	 *            Write image into data set. Calls
+	 *            {@link DvidImage8Writer#writeImage(RandomAccessibleInterval, int, int[], int[])}
+	 *            with iterationAxis set to 2.
+	 */
+	public void writeImage(
+			RandomAccessibleInterval< T > image,
+			final int[] steps,
+			final int[] offset )
+	{
+		this.writeImage( image, 2, steps, offset );
+	}
+
+	/**
+	 * @param image
+	 *            Image to be stored in dvid server.
+	 * @param iterationAxis
+	 *            Along which axis to iterate.
+	 * @param steps
+	 *            Step sizes along each axis.
+	 * @param offset
+	 *            Offset target position by offset.
+	 * 
+	 *            Write image into data set. Calls
+	 *            {@link DvidImage8Writer#writeImage(RandomAccessibleInterval, int, int[], int[], RealType)}
+	 *            with borderExtension set to 0.
+	 */
+	public void writeImage(
+			RandomAccessibleInterval< T > image,
+			final int iterationAxis,
+			final int[] steps,
+			final int[] offset )
+	{
+		T borderExtension = image.randomAccess().get().createVariable();
+		borderExtension.setZero();
+		this.writeImage( image, iterationAxis, steps, offset, borderExtension );
+	}
+
+	/**
+	 * @param image
+	 *            Image to be stored in dvid server.
+	 * @param iterationAxis
+	 *            Along which axis to iterate.
+	 * @param steps
+	 *            Step sizes along each axis.
+	 * @param offset
+	 *            Offset target position by offset.
+	 * @param borderExtension
+	 *            Extend border with this value.
+	 * 
+	 *            Write image into data set. The image will be divided into
+	 *            blocks as defined by steps. The target coordinates will be the
+	 *            image coordinates shifted by offset.
+	 */
+	public void writeImage(
+			RandomAccessibleInterval< T > image,
+			final int iterationAxis,
+			final int[] steps,
+			final int[] offset,
+			T borderExtension )
+	{
+		// realX ensures that realX[i] is integer multiple of blockSize
+		long[] realDim = new long[ image.numDimensions() ];
+		image.dimensions( realDim );
+		adaptToBlockSize( realDim, this.blockSize );
+		int[] realSteps = adaptToBlockSize( steps.clone(), this.blockSize );
+
+		// For now, assume always that data is in [0,1,2] == "xyz" format.
+		// Do we need flexibility to allow for different orderings?
+		int[] dims = new int[ image.numDimensions() ];
+		for ( int d = 0; d < image.numDimensions(); ++d )
+			dims[ d ] = d;
+
+		// stepSize as long[], needed for BlockedInterval
+		long[] stepSize = new long[ image.numDimensions() ];
+		for ( int i = 0; i < stepSize.length; i++ )
+			stepSize[ i ] = realSteps[ i ];
+
+		// Create BlockedInterval that allows for flat iteration and intuitive
+		// hyperslicing.
+		// Go along iterationAxis and hyperslice, then iterate over each
+		// hyperslice.
+		int[] withinBlockOffset = blockSize.clone();
+		long min[] = new long[ withinBlockOffset.length ];
+		long[] length = new long[ min.length ];
+		int[] realOffset = new int[ min.length ];
+		for ( int d = 0; d < withinBlockOffset.length; ++d )
+		{
+			int off = offset[ d ] % blockSize[ d ];
+			realOffset[ d ] = offset[ d ] - off;
+			withinBlockOffset[ d ] = off;
+			min[ d ] = -off;
+			length[ d ] = image.dimension( d ) + off;
+		}
+		IntervalView< T > shiftedImage = Views.offsetInterval( Views.extendValue( image, borderExtension ), min, length );
+		BlockedInterval< T > blockedImage = BlockedInterval.createValueExtended( shiftedImage, stepSize, borderExtension );
+		for ( int a = 0, aUnitIncrement = 0; a < shiftedImage.dimension( iterationAxis ); ++aUnitIncrement, a += realSteps[ iterationAxis ] )
+		{
+			IntervalView< RandomAccessibleInterval< T >> hs = 
+					Views.hyperSlice( blockedImage, iterationAxis, aUnitIncrement );
+			Cursor< RandomAccessibleInterval< T >> cursor = Views.flatIterable( hs ).cursor();
+			while ( cursor.hasNext() )
+			{
+				RandomAccessibleInterval< T > block = cursor.next();
+				int[] localOffset = realOffset.clone();
+				localOffset[ iterationAxis ] += a;
+				for ( int i = 0, k = 0; i < localOffset.length; i++ )
+				{
+					if ( i == iterationAxis )
+						continue;
+					localOffset[ i ] += cursor.getIntPosition( k++ ) * stepSize[ i ];
+				}
+				try
+				{
+					this.writeBlock( block, dims, localOffset );
+				}
+				catch ( IOException e )
+				{
+					System.err.println( "Failed to write block: " + dataset.getRequestString( DatasetBlkUint8.getIntervalRequestString( image, realSteps ) ) );
+					e.printStackTrace();
+				}
+			}
+		}
+
+		return;
+	}
+
+	/**
+	 * @param input
+	 *            Block of data to be written to dvid data set.
+	 * @param dims
+	 *            Interpretation of the dimensionality of the block, e.g.
+	 *            [0,1,2] corresponds to "xyz".
+	 * @param offset
+	 *            Position of the "upper left" corner of the block within the
+	 *            dvid coordinate system.
+	 * @throws IOException
+	 * 
+	 *             Write block into dvid data set at position specified by
+	 *             offset using http POST request.
+	 */
+	public void writeBlock(
+			RandomAccessibleInterval< T > input,
+			final int[] dims,
+			final int[] offset ) throws IOException
+	{
+		// Offset and block dimensions must be integer multiples of
+		// this.blockSize.
+		// For now add the asserts, maybe make this method private/protected and
+		// have
+		// enclosing method take care of it.
+
+		for ( int d = 0; d < input.numDimensions(); ++d )
+		{
+			assert offset[ d ] % this.blockSize[ d ] == 0;
+			assert input.dimension( d ) % this.blockSize[ d ] == 0;
+		}
+		
+		dataset.put( input, offset );
+
+	}
+
+	/**
+	 * @param input
+	 *            Integer array corresponding to be adapted (will be modified).
+	 * @param blockSize
+	 *            Block size.
+	 * @return Modified input.
+	 * 
+	 *         When sending POST request to dvid, all block sizes and offsets
+	 *         need to be integral multiples of blockSize. This is a convenience
+	 *         function to modify integer arrays accordingly.
+	 */
+	public static int[] adaptToBlockSize( int[] input, final int[]blockSize )
+	{
+		for ( int d = 0; d < input.length; ++d )
+		{
+			int val = input[ d ];
+			int bs = blockSize[ d ];
+			int mod = val % bs;
+			if ( mod > 0 )
+				val += bs - mod;
+			input[ d ] = val;
+		}
+		return input;
+	}
+
+	/**
+	 * @param input
+	 *            Long array corresponding to be adapted (will be modified).
+	 * @param blockSize
+	 *            Block size.
+	 * @return Modified input.
+	 * 
+	 *         When sending POST request to dvid, all block sizes and offsets
+	 *         need to be integral multiples of blockSize. This is a convenience
+	 *         function to modify long arrays accordingly.
+	 */
+	public static long[] adaptToBlockSize( long[] input, final int[] blockSize )
+	{
+		for ( int d = 0; d < input.length; ++d )
+		{
+			long val = input[ d ];
+			int bs = blockSize[d];
+			long mod = val % bs;
+			if ( mod > 0 )
+				val += bs - mod;
+			input[ d ] = val;
+		}
+		return input;
+	}
+}

--- a/src/main/java/bdv/img/dvid/DvidImage32Writer.java
+++ b/src/main/java/bdv/img/dvid/DvidImage32Writer.java
@@ -46,6 +46,7 @@ public class DvidImage32Writer extends AbstractDvidImageWriter< UnsignedIntType 
 	 * @throws JsonSyntaxException 
 	 **/
 	public DvidImage32Writer( String url, String uuid, String dataSet )
+			throws JsonSyntaxException, JsonIOException, IOException
 	{
 		this( url, uuid, dataSet, DatasetBlk.defaultBlockSize() );
 	}
@@ -67,6 +68,7 @@ public class DvidImage32Writer extends AbstractDvidImageWriter< UnsignedIntType 
 	 * @throws JsonSyntaxException 
 	 */
 	public DvidImage32Writer( String url, String uuid, final String dataSetName, final int[] blockSize )
+			throws JsonSyntaxException, JsonIOException, IOException
 	{
 		this( new DatasetBlkRGBA( new Repository( url, uuid ).getRootNode(), dataSetName ), blockSize );
 	}

--- a/src/main/java/bdv/img/dvid/DvidImage32Writer.java
+++ b/src/main/java/bdv/img/dvid/DvidImage32Writer.java
@@ -1,20 +1,21 @@
 package bdv.img.dvid;
 
 import java.io.IOException;
+import java.util.Random;
 
 import com.google.gson.JsonIOException;
 import com.google.gson.JsonSyntaxException;
 
-import bdv.util.BlockedInterval;
 import bdv.util.dvid.DatasetBlk;
 import bdv.util.dvid.DatasetBlkRGBA;
-import bdv.util.dvid.DatasetBlkUint8;
 import bdv.util.dvid.Repository;
-import net.imglib2.Cursor;
 import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.array.ArrayCursor;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.basictypeaccess.array.IntArray;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.integer.UnsignedIntType;
-import net.imglib2.view.IntervalView;
 import net.imglib2.view.Views;
 
 /**
@@ -24,12 +25,8 @@ import net.imglib2.view.Views;
  *         into an existing dvid repository/dataset.
  *
  */
-public class DvidImage32Writer
+public class DvidImage32Writer extends AbstractDvidImageWriter< UnsignedIntType >
 {
-
-	private final DatasetBlkRGBA dataset;
-
-	private final int[] blockSize;
 
 	/**
 	 * @param url
@@ -76,220 +73,12 @@ public class DvidImage32Writer
 	
 	public DvidImage32Writer( DatasetBlkRGBA dataset, int[] blockSize )
 	{
-		this.dataset = dataset;
-		this.blockSize = blockSize;
+		super( dataset, blockSize );
 	}
 	
 	public DvidImage32Writer( DatasetBlkRGBA dataset ) throws JsonSyntaxException, JsonIOException, IOException
 	{
 		this( dataset, dataset.getBlockSize() );
-	}
-
-	/**
-	 * @param image
-	 *            Image to be stored in dvid server.
-	 * @param iterationAxis
-	 *            Along which axis to iterate.
-	 * @param steps
-	 *            Step sizes along each axis.
-	 * @param offset
-	 *            Offset target position by offset.
-	 * 
-	 *            Write image into data set. Calls
-	 *            {@link DvidImage32Writer#writeImage(RandomAccessibleInterval, int, int[], int[])}
-	 *            with iterationAxis set to 2.
-	 */
-	public void writeImage(
-			RandomAccessibleInterval< UnsignedIntType > image,
-			final int[] steps,
-			final int[] offset )
-	{
-		this.writeImage( image, 2, steps, offset );
-	}
-
-	/**
-	 * @param image
-	 *            Image to be stored in dvid server.
-	 * @param iterationAxis
-	 *            Along which axis to iterate.
-	 * @param steps
-	 *            Step sizes along each axis.
-	 * @param offset
-	 *            Offset target position by offset.
-	 * 
-	 *            Write image into data set. Calls
-	 *            {@link DvidImage32Writer#writeImage(RandomAccessibleInterval, int, int[], int[], RealType)}
-	 *            with borderExtension set to 0.
-	 */
-	public void writeImage(
-			RandomAccessibleInterval< UnsignedIntType > image,
-			final int iterationAxis,
-			final int[] steps,
-			final int[] offset )
-	{
-		this.writeImage( image, iterationAxis, steps, offset, new UnsignedIntType( 0 ) );
-	}
-
-	/**
-	 * @param image
-	 *            Image to be stored in dvid server.
-	 * @param iterationAxis
-	 *            Along which axis to iterate.
-	 * @param steps
-	 *            Step sizes along each axis.
-	 * @param offset
-	 *            Offset target position by offset.
-	 * @param borderExtension
-	 *            Extend border with this value.
-	 * 
-	 *            Write image into data set. The image will be divided into
-	 *            blocks as defined by steps. The target coordinates will be the
-	 *            image coordinates shifted by offset.
-	 */
-	public void writeImage(
-			RandomAccessibleInterval< UnsignedIntType > image,
-			final int iterationAxis,
-			final int[] steps,
-			final int[] offset,
-			UnsignedIntType borderExtension )
-	{
-		// realX ensures that realX[i] is integer multiple of blockSize
-		long[] realDim = new long[ image.numDimensions() ];
-		image.dimensions( realDim );
-		adaptToBlockSize( realDim, this.blockSize );
-		int[] realSteps = adaptToBlockSize( steps.clone(), this.blockSize );
-		int[] realOffset = adaptToBlockSize( offset.clone(), this.blockSize );
-
-		// For now, assume always that data is in [0,1,2] == "xyz" format.
-		// Do we need flexibility to allow for different orderings?
-		int[] dims = new int[ image.numDimensions() ];
-		for ( int d = 0; d < image.numDimensions(); ++d )
-			dims[ d ] = d;
-
-		// stepSize as long[], needed for BlockedInterval
-		long[] stepSize = new long[ image.numDimensions() ];
-		for ( int i = 0; i < stepSize.length; i++ )
-			stepSize[ i ] = realSteps[ i ];
-
-		// Create BlockedInterval that allows for flat iteration and intuitive
-		// hyperslicing.
-		// Go along iterationAxis and hyperslice, then iterate over each
-		// hyperslice.
-		BlockedInterval< UnsignedIntType > blockedImage = BlockedInterval.createZeroExtended( image, stepSize );
-		for ( int a = 0, aUnitIncrement = 0; a < image.dimension( iterationAxis ); ++aUnitIncrement, a += realSteps[ iterationAxis ] )
-		{
-			IntervalView< RandomAccessibleInterval< UnsignedIntType >> hs = 
-					Views.hyperSlice( blockedImage, iterationAxis, aUnitIncrement );
-			Cursor< RandomAccessibleInterval< UnsignedIntType >> cursor = Views.flatIterable( hs ).cursor();
-			while ( cursor.hasNext() )
-			{
-				RandomAccessibleInterval< UnsignedIntType > block = cursor.next();
-				int[] localOffset = realOffset.clone();
-				localOffset[ iterationAxis ] = a;
-				for ( int i = 0, k = 0; i < localOffset.length; i++ )
-				{
-					if ( i == iterationAxis )
-						continue;
-					localOffset[ i ] += cursor.getIntPosition( k++ ) * stepSize[ i ];
-				}
-				try
-				{
-					this.writeBlock( block, dims, localOffset );
-				}
-				catch ( IOException e )
-				{
-					System.err.println( "Failed to write block: " + dataset.getRequestString( DatasetBlkUint8.getIntervalRequestString( image, realSteps ) ) );
-					e.printStackTrace();
-				}
-			}
-		}
-
-		return;
-	}
-
-	/**
-	 * @param input
-	 *            Block of data to be written to dvid data set.
-	 * @param dims
-	 *            Interpretation of the dimensionality of the block, e.g.
-	 *            [0,1,2] corresponds to "xyz".
-	 * @param offset
-	 *            Position of the "upper left" corner of the block within the
-	 *            dvid coordinate system.
-	 * @throws IOException
-	 * 
-	 *             Write block into dvid data set at position specified by
-	 *             offset using http POST request.
-	 */
-	public void writeBlock(
-			RandomAccessibleInterval< UnsignedIntType > input,
-			final int[] dims,
-			final int[] offset ) throws IOException
-	{
-		// Offset and block dimensions must be integer multiples of
-		// this.blockSize.
-		// For now add the asserts, maybe make this method private/protected and
-		// have
-		// enclosing method take care of it.
-
-		for ( int d = 0; d < input.numDimensions(); ++d )
-		{
-			assert offset[ d ] % this.blockSize[ d ] == 0;
-			assert input.dimension( d ) % this.blockSize[ d ] == 0;
-		}
-
-		dataset.put( input, offset );
-
-	}
-
-	/**
-	 * @param input
-	 *            Integer array corresponding to be adapted (will be modified).
-	 * @param blockSize
-	 *            Block size.
-	 * @return Modified input.
-	 * 
-	 *         When sending POST request to dvid, all block sizes and offsets
-	 *         need to be integral multiples of blockSize. This is a convenience
-	 *         function to modify integer arrays accordingly.
-	 */
-	public static int[] adaptToBlockSize( int[] input, final int[]blockSize )
-	{
-		for ( int d = 0; d < input.length; ++d )
-		{
-			int val = input[ d ];
-			int bs = blockSize[ d ];
-			int mod = val % bs;
-			if ( mod > 0 )
-				val += bs - mod;
-			input[ d ] = val;
-		}
-		return input;
-	}
-
-	/**
-	 * @param input
-	 *            Long array corresponding to be adapted (will be modified).
-	 * @param blockSize
-	 *            Block size.
-	 * @return Modified input.
-	 * 
-	 *         When sending POST request to dvid, all block sizes and offsets
-	 *         need to be integral multiples of blockSize. This is a convenience
-	 *         function to modify long arrays accordingly.
-	 */
-	public static long[] adaptToBlockSize( long[] input, final int[] blockSize )
-	{
-		for ( int d = 0; d < input.length; ++d )
-		{
-			long val = input[ d ];
-			int bs = blockSize[d];
-			long mod = val % bs;
-			if ( mod > 0 )
-				val += bs - mod;
-			input[ d ] = val;
-		}
-		return input;
 	}
 
 	/**
@@ -302,60 +91,60 @@ public class DvidImage32Writer
 	public static void main( String[] args ) throws IOException
 	{
 
-//		// this is for testing purposes, modify apiUrl, uuid and dataSet
-//		// according to your needs
-//		// if values received from server differ from input, these values will
-//		// be printed to stdout
-//		// otherwise no output
-//
-//		String url = "http://vm570.int.janelia.org:8080";
-//		String uuid = "9c7cc44aa0544d33905ce82d153e2544";
-//		String dataSet = "bigcat-test2";
-//		
-//		Repository repo = new Repository( url, uuid );
-//
-//		Random rng = new Random();
-//
-//		int[] dim = new int[] { 200, 200, 96 };
-//		long[] longDim = new long[ dim.length ];
-//		for ( int i = 0; i < longDim.length; i++ )
-//			longDim[ i ] = dim[ i ];
-//		ArrayImg< FloatType, FloatArray > ref = ArrayImgs.floats( longDim );
-//		for ( FloatType r : ref )
-//			r.set( rng.nextFloat() );
-//
-//		DvidImage32Writer writer = new DvidImage32Writer( url, uuid, dataSet );
-//		int[] steps = new int[] { 200, 200, 32 };
-//		int[] offset = new int[] { 0, 0, 0 };
-//		Converter< FloatType, UnsignedLongType > converter = new Converter< FloatType, UnsignedLongType >()
-//		{
-//
-//			@Override
-//			public void convert( FloatType input, UnsignedLongType output )
-//			{
-//				output.set( Float.floatToIntBits( input.get() ) | 0l );
-//			}};
-//			
-//		ConvertedRandomAccessibleInterval< FloatType, UnsignedLongType > refLong = 
-//				new ConvertedRandomAccessibleInterval<FloatType,UnsignedLongType>( ref, converter, new UnsignedLongType() );
-//		writer.writeImage( refLong, steps, offset );
-//
-//		// read image from dvid server
-//		Node node = repo.getRootNode();
-//		DatasetBlkImage  ds = new DatasetBlkImage ( node, "bigcat-test2" );
-////		ArrayImg< UnsignedIntType, IntArray > target = ArrayImgs.unsignedInts( longDim );
-//		ArrayImg< UnsignedLongType, ? > target = new ArrayImgFactory<UnsignedLongType>().create( longDim, new UnsignedLongType() );
-//		ds.get( target, offset );
-//		
-//		ArrayCursor< UnsignedLongType > t = target.cursor();
-//		for ( UnsignedLongType r : Views.flatIterable( refLong ) )
-//		{
-//			long comp = r.get();
-//			long test = t.next().getIntegerLong();
-//			if ( test != comp )
-//				System.out.println( test + " " + comp );
-//		}
-//		System.out.println( "Done." );
+		// this is for testing purposes, modify apiUrl, uuid and dataSet
+		// according to your needs
+		// if values received from server differ from input, these values will
+		// be printed to stdout
+		// otherwise no output
+
+		String url = "http://vm570.int.janelia.org:8080";
+		String uuid = "4668221206e047648f622dc4690ff7dc";
+		String dataSet = "bigcat-uint32-write";
+		
+		Repository repo = new Repository( url, uuid );
+		
+		try {
+			repo.getRootNode().createDataset( dataSet, DatasetBlkRGBA.TYPE );
+		}
+		catch ( Exception e ) {
+			e.printStackTrace( System.err );
+		}
+		
+		DatasetBlkRGBA ds = new DatasetBlkRGBA( repo.getRootNode(), dataSet );
+
+		Random rng = new Random();
+
+		int[] dim = new int[] { 200, 200, 96 };
+		long[] longDim = new long[ dim.length ];
+		for ( int i = 0; i < longDim.length; i++ )
+			longDim[ i ] = dim[ i ];
+		ArrayImg< UnsignedIntType, IntArray > ref = ArrayImgs.unsignedInts( longDim );
+		for ( UnsignedIntType r : ref )
+			r.set( rng.nextInt( 0xff ) );
+
+		DvidImage32Writer writer = new DvidImage32Writer( ds );
+		int[] steps = new int[] { 200, 200, 32 };
+		int[] offset = new int[] { 1, 15, 65 };
+//		offset = new int[] { 32, 64, 96 };
+		
+		writer.writeImage( ref, steps, offset );
+
+		// read image from dvid server
+		ArrayImg< UnsignedIntType, IntArray > target = ArrayImgs.unsignedInts( longDim );
+		ds.get( target, offset );
+		
+		ArrayCursor< UnsignedIntType > t = target.cursor();
+		for ( UnsignedIntType r : Views.flatIterable( ref ) )
+		{
+			long comp = r.getIntegerLong();
+			long test = t.next().getIntegerLong();
+			if ( test != comp )
+			{
+				System.out.println( test + " " + comp );
+				System.exit( 9001 );
+			}
+		}
+		System.out.println( "Done." );
 	}
 
 }

--- a/src/main/java/bdv/img/dvid/DvidImage8Writer.java
+++ b/src/main/java/bdv/img/dvid/DvidImage8Writer.java
@@ -1,19 +1,21 @@
 package bdv.img.dvid;
 
 import java.io.IOException;
+import java.util.Random;
 
 import com.google.gson.JsonIOException;
 import com.google.gson.JsonSyntaxException;
 
-import bdv.util.BlockedInterval;
 import bdv.util.dvid.DatasetBlk;
 import bdv.util.dvid.DatasetBlkUint8;
 import bdv.util.dvid.Repository;
-import net.imglib2.Cursor;
 import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.array.ArrayCursor;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.basictypeaccess.array.ByteArray;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
-import net.imglib2.view.IntervalView;
 import net.imglib2.view.Views;
 
 /**
@@ -23,12 +25,8 @@ import net.imglib2.view.Views;
  *         into an existing dvid repository/dataset.
  *
  */
-public class DvidImage8Writer
+public class DvidImage8Writer extends AbstractDvidImageWriter< UnsignedByteType >
 {
-
-	private final DatasetBlkUint8 dataset;
-
-	private final int[] blockSize;
 
 	/**
 	 * @param url
@@ -75,221 +73,12 @@ public class DvidImage8Writer
 	
 	public DvidImage8Writer( DatasetBlkUint8 dataset, int[] blockSize )
 	{
-		this.dataset = dataset;
-		this.blockSize = blockSize;
+		super( dataset, blockSize );
 	}
 	
 	public DvidImage8Writer( DatasetBlkUint8 dataset ) throws JsonSyntaxException, JsonIOException, IOException
 	{
 		this( dataset, dataset.getBlockSize() );
-	}
-
-	/**
-	 * @param image
-	 *            Image to be stored in dvid server.
-	 * @param iterationAxis
-	 *            Along which axis to iterate.
-	 * @param steps
-	 *            Step sizes along each axis.
-	 * @param offset
-	 *            Offset target position by offset.
-	 * 
-	 *            Write image into data set. Calls
-	 *            {@link DvidImage8Writer#writeImage(RandomAccessibleInterval, int, int[], int[])}
-	 *            with iterationAxis set to 2.
-	 */
-	public void writeImage(
-			RandomAccessibleInterval< UnsignedByteType > image,
-			final int[] steps,
-			final int[] offset )
-	{
-		this.writeImage( image, 2, steps, offset );
-	}
-
-	/**
-	 * @param image
-	 *            Image to be stored in dvid server.
-	 * @param iterationAxis
-	 *            Along which axis to iterate.
-	 * @param steps
-	 *            Step sizes along each axis.
-	 * @param offset
-	 *            Offset target position by offset.
-	 * 
-	 *            Write image into data set. Calls
-	 *            {@link DvidImage8Writer#writeImage(RandomAccessibleInterval, int, int[], int[], RealType)}
-	 *            with borderExtension set to 0.
-	 */
-	public void writeImage(
-			RandomAccessibleInterval< UnsignedByteType > image,
-			final int iterationAxis,
-			final int[] steps,
-			final int[] offset )
-	{
-		this.writeImage( image, iterationAxis, steps, offset, new UnsignedByteType( 0 ) );
-	}
-
-	/**
-	 * @param image
-	 *            Image to be stored in dvid server.
-	 * @param iterationAxis
-	 *            Along which axis to iterate.
-	 * @param steps
-	 *            Step sizes along each axis.
-	 * @param offset
-	 *            Offset target position by offset.
-	 * @param borderExtension
-	 *            Extend border with this value.
-	 * 
-	 *            Write image into data set. The image will be divided into
-	 *            blocks as defined by steps. The target coordinates will be the
-	 *            image coordinates shifted by offset.
-	 */
-	public void writeImage(
-			RandomAccessibleInterval< UnsignedByteType > image,
-			final int iterationAxis,
-			final int[] steps,
-			final int[] offset,
-			UnsignedByteType borderExtension )
-	{
-		// realX ensures that realX[i] is integer multiple of blockSize
-		long[] realDim = new long[ image.numDimensions() ];
-		image.dimensions( realDim );
-		adaptToBlockSize( realDim, this.blockSize );
-		int[] realSteps = adaptToBlockSize( steps.clone(), this.blockSize );
-		int[] realOffset = adaptToBlockSize( offset.clone(), this.blockSize );
-
-		// For now, assume always that data is in [0,1,2] == "xyz" format.
-		// Do we need flexibility to allow for different orderings?
-		int[] dims = new int[ image.numDimensions() ];
-		for ( int d = 0; d < image.numDimensions(); ++d )
-			dims[ d ] = d;
-
-		// stepSize as long[], needed for BlockedInterval
-		long[] stepSize = new long[ image.numDimensions() ];
-		for ( int i = 0; i < stepSize.length; i++ )
-			stepSize[ i ] = realSteps[ i ];
-
-		// Create BlockedInterval that allows for flat iteration and intuitive
-		// hyperslicing.
-		// Go along iterationAxis and hyperslice, then iterate over each
-		// hyperslice.
-		BlockedInterval< UnsignedByteType > blockedImage = BlockedInterval.createZeroExtended( image, stepSize );
-		for ( int a = 0, aUnitIncrement = 0; a < image.dimension( iterationAxis ); ++aUnitIncrement, a += realSteps[ iterationAxis ] )
-		{
-			IntervalView< RandomAccessibleInterval< UnsignedByteType >> hs = 
-					Views.hyperSlice( blockedImage, iterationAxis, aUnitIncrement );
-			Cursor< RandomAccessibleInterval< UnsignedByteType >> cursor = Views.flatIterable( hs ).cursor();
-			while ( cursor.hasNext() )
-			{
-				RandomAccessibleInterval< UnsignedByteType > block = cursor.next();
-				System.out.println( cursor.getLongPosition( 0 ) + " " + cursor.getLongPosition( 1 ) + " " + a );
-				int[] localOffset = realOffset.clone();
-				localOffset[ iterationAxis ] = a;
-				for ( int i = 0, k = 0; i < localOffset.length; i++ )
-				{
-					if ( i == iterationAxis )
-						continue;
-					localOffset[ i ] += cursor.getIntPosition( k++ ) * stepSize[ i ];
-				}
-				try
-				{
-					this.writeBlock( block, dims, localOffset );
-				}
-				catch ( IOException e )
-				{
-					System.err.println( "Failed to write block: " + dataset.getRequestString( DatasetBlkUint8.getIntervalRequestString( image, realSteps ) ) );
-					e.printStackTrace();
-				}
-			}
-		}
-
-		return;
-	}
-
-	/**
-	 * @param input
-	 *            Block of data to be written to dvid data set.
-	 * @param dims
-	 *            Interpretation of the dimensionality of the block, e.g.
-	 *            [0,1,2] corresponds to "xyz".
-	 * @param offset
-	 *            Position of the "upper left" corner of the block within the
-	 *            dvid coordinate system.
-	 * @throws IOException
-	 * 
-	 *             Write block into dvid data set at position specified by
-	 *             offset using http POST request.
-	 */
-	public void writeBlock(
-			RandomAccessibleInterval< UnsignedByteType > input,
-			final int[] dims,
-			final int[] offset ) throws IOException
-	{
-		// Offset and block dimensions must be integer multiples of
-		// this.blockSize.
-		// For now add the asserts, maybe make this method private/protected and
-		// have
-		// enclosing method take care of it.
-
-		for ( int d = 0; d < input.numDimensions(); ++d )
-		{
-			assert offset[ d ] % this.blockSize[ d ] == 0;
-			assert input.dimension( d ) % this.blockSize[ d ] == 0;
-		}
-
-		dataset.put( input, offset );
-
-	}
-
-	/**
-	 * @param input
-	 *            Integer array corresponding to be adapted (will be modified).
-	 * @param blockSize
-	 *            Block size.
-	 * @return Modified input.
-	 * 
-	 *         When sending POST request to dvid, all block sizes and offsets
-	 *         need to be integral multiples of blockSize. This is a convenience
-	 *         function to modify integer arrays accordingly.
-	 */
-	public static int[] adaptToBlockSize( int[] input, final int[]blockSize )
-	{
-		for ( int d = 0; d < input.length; ++d )
-		{
-			int val = input[ d ];
-			int bs = blockSize[ d ];
-			int mod = val % bs;
-			if ( mod > 0 )
-				val += bs - mod;
-			input[ d ] = val;
-		}
-		return input;
-	}
-
-	/**
-	 * @param input
-	 *            Long array corresponding to be adapted (will be modified).
-	 * @param blockSize
-	 *            Block size.
-	 * @return Modified input.
-	 * 
-	 *         When sending POST request to dvid, all block sizes and offsets
-	 *         need to be integral multiples of blockSize. This is a convenience
-	 *         function to modify long arrays accordingly.
-	 */
-	public static long[] adaptToBlockSize( long[] input, final int[] blockSize )
-	{
-		for ( int d = 0; d < input.length; ++d )
-		{
-			long val = input[ d ];
-			int bs = blockSize[d];
-			long mod = val % bs;
-			if ( mod > 0 )
-				val += bs - mod;
-			input[ d ] = val;
-		}
-		return input;
 	}
 
 	/**
@@ -302,60 +91,60 @@ public class DvidImage8Writer
 	public static void main( String[] args ) throws IOException
 	{
 
-//		// this is for testing purposes, modify apiUrl, uuid and dataSet
-//		// according to your needs
-//		// if values received from server differ from input, these values will
-//		// be printed to stdout
-//		// otherwise no output
-//
-//		String url = "http://vm570.int.janelia.org:8080";
-//		String uuid = "9c7cc44aa0544d33905ce82d153e2544";
-//		String dataSet = "bigcat-test2";
-//		
-//		Repository repo = new Repository( url, uuid );
-//
-//		Random rng = new Random();
-//
-//		int[] dim = new int[] { 200, 200, 96 };
-//		long[] longDim = new long[ dim.length ];
-//		for ( int i = 0; i < longDim.length; i++ )
-//			longDim[ i ] = dim[ i ];
-//		ArrayImg< FloatType, FloatArray > ref = ArrayImgs.floats( longDim );
-//		for ( FloatType r : ref )
-//			r.set( rng.nextFloat() );
-//
-//		DvidImage32Writer writer = new DvidImage32Writer( url, uuid, dataSet );
-//		int[] steps = new int[] { 200, 200, 32 };
-//		int[] offset = new int[] { 0, 0, 0 };
-//		Converter< FloatType, UnsignedLongType > converter = new Converter< FloatType, UnsignedLongType >()
-//		{
-//
-//			@Override
-//			public void convert( FloatType input, UnsignedLongType output )
-//			{
-//				output.set( Float.floatToIntBits( input.get() ) | 0l );
-//			}};
-//			
-//		ConvertedRandomAccessibleInterval< FloatType, UnsignedLongType > refLong = 
-//				new ConvertedRandomAccessibleInterval<FloatType,UnsignedLongType>( ref, converter, new UnsignedLongType() );
-//		writer.writeImage( refLong, steps, offset );
-//
-//		// read image from dvid server
-//		Node node = repo.getRootNode();
-//		DatasetBlkImage  ds = new DatasetBlkImage ( node, "bigcat-test2" );
-////		ArrayImg< UnsignedIntType, IntArray > target = ArrayImgs.unsignedInts( longDim );
-//		ArrayImg< UnsignedLongType, ? > target = new ArrayImgFactory<UnsignedLongType>().create( longDim, new UnsignedLongType() );
-//		ds.get( target, offset );
-//		
-//		ArrayCursor< UnsignedLongType > t = target.cursor();
-//		for ( UnsignedLongType r : Views.flatIterable( refLong ) )
-//		{
-//			long comp = r.get();
-//			long test = t.next().getIntegerLong();
-//			if ( test != comp )
-//				System.out.println( test + " " + comp );
-//		}
-//		System.out.println( "Done." );
+		// this is for testing purposes, modify apiUrl, uuid and dataSet
+		// according to your needs
+		// if values received from server differ from input, these values will
+		// be printed to stdout
+		// otherwise no output
+
+		String url = "http://vm570.int.janelia.org:8080";
+		String uuid = "4668221206e047648f622dc4690ff7dc";
+		String dataSet = "bigcat-uint8-write-3";
+		
+		Repository repo = new Repository( url, uuid );
+		
+		try {
+			repo.getRootNode().createDataset( dataSet, DatasetBlkUint8.TYPE );
+		}
+		catch ( Exception e ) {
+			e.printStackTrace( System.err );
+		}
+		
+		DatasetBlkUint8 ds = new DatasetBlkUint8( repo.getRootNode(), dataSet );
+
+		Random rng = new Random();
+
+		int[] dim = new int[] { 200, 200, 96 };
+		long[] longDim = new long[ dim.length ];
+		for ( int i = 0; i < longDim.length; i++ )
+			longDim[ i ] = dim[ i ];
+		ArrayImg< UnsignedByteType, ByteArray > ref = ArrayImgs.unsignedBytes( longDim );
+		for ( UnsignedByteType r : ref )
+			r.set( rng.nextInt( 0xff ) );
+
+		DvidImage8Writer writer = new DvidImage8Writer( ds );
+		int[] steps = new int[] { 200, 200, 32 };
+		int[] offset = new int[] { 1, 15, 65 };
+//		offset = new int[] { 32, 64, 96 };
+		
+		writer.writeImage( ref, steps, offset );
+
+		// read image from dvid server
+		ArrayImg< UnsignedByteType, ByteArray > target = ArrayImgs.unsignedBytes( longDim );
+		ds.get( target, offset );
+		
+		ArrayCursor< UnsignedByteType > t = target.cursor();
+		for ( UnsignedByteType r : Views.flatIterable( ref ) )
+		{
+			long comp = r.getIntegerLong();
+			long test = t.next().getIntegerLong();
+			if ( test != comp )
+			{
+				System.out.println( test + " " + comp );
+				System.exit( 9001 );
+			}
+		}
+		System.out.println( "Done." );
 	}
 
 }

--- a/src/main/java/bdv/img/dvid/DvidImage8Writer.java
+++ b/src/main/java/bdv/img/dvid/DvidImage8Writer.java
@@ -46,6 +46,7 @@ public class DvidImage8Writer extends AbstractDvidImageWriter< UnsignedByteType 
 	 * @throws JsonSyntaxException 
 	 **/
 	public DvidImage8Writer( String url, String uuid, String dataSet )
+			throws JsonSyntaxException, JsonIOException, IOException
 	{
 		this( url, uuid, dataSet, DatasetBlk.defaultBlockSize() );
 	}
@@ -67,6 +68,7 @@ public class DvidImage8Writer extends AbstractDvidImageWriter< UnsignedByteType 
 	 * @throws JsonSyntaxException 
 	 */
 	public DvidImage8Writer( String url, String uuid, final String dataSetName, final int[] blockSize )
+			throws JsonSyntaxException, JsonIOException, IOException
 	{
 		this( new DatasetBlkUint8( new Repository( url, uuid ).getRootNode(), dataSetName ), blockSize );
 	}

--- a/src/main/java/bdv/img/dvid/DvidLabelBlkWriter.java
+++ b/src/main/java/bdv/img/dvid/DvidLabelBlkWriter.java
@@ -58,6 +58,7 @@ public class DvidLabelBlkWriter
 	 * @throws JsonSyntaxException 
 	 **/
 	public DvidLabelBlkWriter( String url, String uuid, String dataSet )
+			throws JsonSyntaxException, JsonIOException, IOException
 	{
 		this( url, uuid, dataSet, DatasetBlk.defaultBlockSize() );
 	}
@@ -79,6 +80,7 @@ public class DvidLabelBlkWriter
 	 * @throws JsonSyntaxException 
 	 */
 	public DvidLabelBlkWriter( String url, String uuid, final String dataSetName, final int[] blockSize )
+			throws JsonSyntaxException, JsonIOException, IOException
 	{
 		this( new DatasetBlkLabel( new Repository( url, uuid ).getRootNode(), dataSetName ), blockSize );
 	}

--- a/src/main/java/bdv/img/dvid/DvidLabels64Writer.java
+++ b/src/main/java/bdv/img/dvid/DvidLabels64Writer.java
@@ -48,6 +48,7 @@ public class DvidLabels64Writer extends AbstractDvidImageWriter< UnsignedLongTyp
 	 * @throws JsonSyntaxException 
 	 **/
 	public DvidLabels64Writer( final String url, final String uuid, final String dataSet )
+			throws JsonSyntaxException, JsonIOException, IOException
 	{
 		this( url, uuid, dataSet, DatasetBlk.defaultBlockSize() );
 	}
@@ -69,6 +70,7 @@ public class DvidLabels64Writer extends AbstractDvidImageWriter< UnsignedLongTyp
 	 * @throws JsonSyntaxException 
 	 */
 	public DvidLabels64Writer( final String url, final String uuid, final String dataSet, final int[] blockSize )
+			throws JsonSyntaxException, JsonIOException, IOException
 	{
 		this( new DatasetBlkLabel( new Repository( url, uuid ).getRootNode(), dataSet ), blockSize );
 	}

--- a/src/main/java/bdv/img/dvid/DvidNBytesWriter.java
+++ b/src/main/java/bdv/img/dvid/DvidNBytesWriter.java
@@ -1,20 +1,28 @@
 package bdv.img.dvid;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Random;
 
 import com.google.gson.JsonIOException;
-import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
 
-import bdv.util.BlockedInterval;
-import bdv.util.dvid.DatasetBlk;
 import bdv.util.dvid.DatasetBlkUint8;
+import bdv.util.dvid.DatasetNByte;
+import bdv.util.dvid.DatasetNByte.NByteIO;
 import bdv.util.dvid.Repository;
-import bdv.util.http.HttpRequest;
 import net.imglib2.Cursor;
+import net.imglib2.Point;
 import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.array.ArrayRandomAccess;
+import net.imglib2.img.basictypeaccess.array.LongArray;
+import net.imglib2.type.numeric.NumericType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.type.numeric.integer.LongType;
 import net.imglib2.view.IntervalView;
 import net.imglib2.view.Views;
 
@@ -25,13 +33,9 @@ import net.imglib2.view.Views;
  *         into an existing dvid repository/dataset.
  *
  */
-public class DvidNBytesWriter
+public class DvidNBytesWriter< T extends NumericType< T > > extends AbstractDvidImageWriter< T >
 {
 
-	private final DatasetBlkUint8 dataset;
-
-	private final int[] blockSize;
-
 	/**
 	 * @param url
 	 *            Url to dvid server in the form of http://hostname:port
@@ -40,29 +44,7 @@ public class DvidNBytesWriter
 	 *            The root node of the repository will be used for writing.
 	 * @param dataSet
 	 *            Name of the data set within the repository specified by uuid.
-	 *            This data set must be of type imageblk.
-	 * 
-	 *            This calls
-	 *            {@link DvidNBytesWriter#DvidLabels64ByteWriter(String, String, String, int)}
-	 *            with a default block size of 32.
-	 * @throws IOException 
-	 * @throws JsonIOException 
-	 * @throws JsonSyntaxException 
-	 **/
-	public DvidNBytesWriter( String url, String uuid, String dataSet )
-	{
-		this( url, uuid, dataSet, DatasetBlk.defaultBlockSize() );
-	}
-
-	/**
-	 * @param url
-	 *            Url to dvid server in the form of http://hostname:port
-	 * @param uuid
-	 *            Uuid of repository within the dvid server specified by apiUrl.
-	 *            The root node of the repository will be used for writing.
-	 * @param dataSet
-	 *            Name of the data set within the repository specified by uuid.
-	 *            This data set must be of type imageblk
+	 *            This data set must be of type labelblk
 	 * @param blockSize
 	 *            Block size of the data set. Must suit block size stored in
 	 *            dvid server.
@@ -70,231 +52,62 @@ public class DvidNBytesWriter
 	 * @throws JsonIOException 
 	 * @throws JsonSyntaxException 
 	 */
-	public DvidNBytesWriter( String url, String uuid, final String dataSetName, final int[] blockSize )
+	public DvidNBytesWriter( 
+			final String url,
+			final String uuid,
+			final String dataSet,
+			int nBytes,
+			DatasetNByte.NByteIO< T > io ) throws JsonSyntaxException, JsonIOException, IOException
 	{
-		this( new DatasetBlkUint8( new Repository( url, uuid ).getRootNode(), dataSetName ), blockSize );
+		this( new DatasetNByte< T >( new Repository( url, uuid ).getRootNode(), dataSet, nBytes, io ) );
 	}
 	
-	public DvidNBytesWriter( DatasetBlkUint8 dataset, int[] blockSize )
+	public DvidNBytesWriter( DatasetNByte< T > dataset ) throws JsonSyntaxException, JsonIOException, IOException
 	{
-		this.dataset = dataset;
-		this.blockSize = blockSize;
+		super( dataset, dataset.getBlockSize() );
 	}
 	
-	public DvidNBytesWriter( DatasetBlkUint8 dataset ) throws JsonSyntaxException, JsonIOException, IOException
+	@Override
+	public void writeImage( RandomAccessibleInterval<T> image, int[] steps, int[] offset )
 	{
-		this( dataset, dataset.getBlockSize() );
+		for( int d = 0; d < this.blockSize.length; ++d )
+			if( steps[ d ] != this.blockSize[ d ] )
+				throw new IllegalArgumentException( 
+						"steps != blockSize (" +
+						Arrays.toString( steps ) + " != " +
+						Arrays.toString( this.blockSize ) + ")" );
+		super.writeImage( image, steps, offset );
 	}
-
-	/**
-	 * @param image
-	 *            Image to be stored in dvid server.
-	 * @param iterationAxis
-	 *            Along which axis to iterate.
-	 * @param offset
-	 *            Offset target position by offset.
-	 * 
-	 *            Write image into data set. Calls
-	 *            {@link DvidNBytesWriter#writeImage(RandomAccessibleInterval, int, int[], int[])}
-	 *            with iterationAxis set to 2.
-	 */
-	public < T extends RealType< T > > void writeImage(
-			RandomAccessibleInterval< T > image,
-			final int[] offset,
-			final HttpRequest.Writer< T > writer )
+	
+	@Override
+	public void writeImage( RandomAccessibleInterval<T> image, int iterationAxis, int[] steps, int[] offset )
 	{
-		this.writeImage( image, 2, offset, writer );
+		for( int d = 0; d < this.blockSize.length; ++d )
+			if( steps[ d ] != this.blockSize[ d ] )
+				throw new IllegalArgumentException( 
+						"steps != blockSize (" +
+						Arrays.toString( steps ) + " != " +
+						Arrays.toString( this.blockSize ) + ")" );
+		super.writeImage( image, iterationAxis, steps, offset );
 	}
-
-	/**
-	 * @param image
-	 *            Image to be stored in dvid server.
-	 * @param iterationAxis
-	 *            Along which axis to iterate.
-	 * @param offset
-	 *            Offset target position by offset.
-	 * 
-	 *            Write image into data set. Calls
-	 *            {@link DvidNBytesWriter#writeImage(RandomAccessibleInterval, int, int[], int[], RealType)}
-	 *            with borderExtension set to 0.
-	 */
-	public < T extends RealType< T > > void writeImage(
-			RandomAccessibleInterval< T > image,
-			final int iterationAxis,
-			final int[] offset,
-			final HttpRequest.Writer< T > writer )
-	{
-		T zeroExtension = image.randomAccess().get().createVariable();
-		zeroExtension.setZero();
-		this.writeImage( image, iterationAxis, offset, writer, zeroExtension );
-	}
-
-	/**
-	 * @param image
-	 *            Image to be stored in dvid server.
-	 * @param iterationAxis
-	 *            Along which axis to iterate.
-	 * @param offset
-	 *            Offset target position by offset.
-	 * @param borderExtension
-	 *            Extend border with this value.
-	 * 
-	 *            Write image into data set. The image will be divided into
-	 *            blocks as defined by steps. The target coordinates will be the
-	 *            image coordinates shifted by offset.
-	 */
-	public < T extends RealType< T > > void writeImage(
-			RandomAccessibleInterval< T > image,
-			final int iterationAxis,
-			final int[] offset,
-			final HttpRequest.Writer< T > writer,
+	
+	@Override
+	public void writeImage( 
+			RandomAccessibleInterval<T> image,
+			int iterationAxis,
+			int[] steps,
+			int[] offset,
 			T borderExtension )
 	{
-		// realX ensures that realX[i] is integer multiple of blockSize
-		long[] realDim = new long[ image.numDimensions() ];
-		image.dimensions( realDim );
-		adaptToBlockSize( realDim, this.blockSize );
-		int[] realOffset = adaptToBlockSize( offset.clone(), this.blockSize );
-
-		// For now, assume always that data is in [0,1,2] == "xyz" format.
-		// Do we need flexibility to allow for different orderings?
-		int[] dims = new int[ image.numDimensions() ];
-		for ( int d = 0; d < image.numDimensions(); ++d )
-			dims[ d ] = d;
-
-		// stepSize as long[], needed for BlockedInterval
-		long[] stepSize = new long[ image.numDimensions() ];
-		for ( int i = 0; i < stepSize.length; i++ )
-			stepSize[ i ] = blockSize[ i ];
-
-		// Create BlockedInterval that allows for flat iteration and intuitive
-		// hyperslicing.
-		// Go along iterationAxis and hyperslice, then iterate over each
-		// hyperslice.
-		BlockedInterval< T > blockedImage = BlockedInterval.createZeroExtended( image, stepSize );
-		for ( int a = 0, aUnitIncrement = 0; a < image.dimension( iterationAxis ); ++aUnitIncrement, a += stepSize[ iterationAxis ] )
-		{
-			IntervalView< RandomAccessibleInterval< T >> hs = 
-					Views.hyperSlice( blockedImage, iterationAxis, aUnitIncrement );
-			Cursor< RandomAccessibleInterval< T >> cursor = Views.flatIterable( hs ).cursor();
-			while ( cursor.hasNext() )
-			{
-				RandomAccessibleInterval< T > block = cursor.next();
-				System.out.println( cursor.getLongPosition( 0 ) + " " + cursor.getLongPosition( 1 ) + " " + a );
-				int[] localOffset = realOffset.clone();
-				localOffset[ iterationAxis ] = a;
-				for ( int i = 0, k = 0; i < localOffset.length; i++ )
-				{
-					if ( i == iterationAxis )
-						continue;
-					localOffset[ i ] += cursor.getIntPosition( k++ ) * stepSize[ i ];
-				}
-				try
-				{
-					this.writeBlock( block, dims, localOffset, writer );
-				}
-				catch ( IOException e )
-				{
-					System.err.println( "Failed to write block: " + dataset.getRequestString( DatasetBlkUint8.getIntervalRequestString( image, blockSize ) ) );
-					e.printStackTrace();
-				}
-			}
-		}
-
-		return;
+		for( int d = 0; d < this.blockSize.length; ++d )
+			if( steps[ d ] != this.blockSize[ d ] )
+				throw new IllegalArgumentException( 
+						"steps != blockSize (" +
+						Arrays.toString( steps ) + " != " +
+						Arrays.toString( this.blockSize ) + ")" );
+		super.writeImage( image, iterationAxis, this.blockSize, offset, borderExtension );
 	}
-
-	/**
-	 * @param input
-	 *            Block of data to be written to dvid data set.
-	 * @param dims
-	 *            Interpretation of the dimensionality of the block, e.g.
-	 *            [0,1,2] corresponds to "xyz".
-	 * @param offset
-	 *            Position of the "upper left" corner of the block within the
-	 *            dvid coordinate system.
-	 * @throws IOException
-	 * 
-	 *             Write block into dvid data set at position specified by
-	 *             offset using http POST request.
-	 */
-	public < T extends RealType< T > > void writeBlock(
-			RandomAccessibleInterval< T > input,
-			final int[] dims,
-			final int[] offset,
-			final HttpRequest.Writer< T > writer ) throws IOException
-	{
-		// Offset and block dimensions must be integer multiples of
-		// this.blockSize.
-		// For now add the asserts, maybe make this method private/protected and
-		// have
-		// enclosing method take care of it.
-		
-		int sizeInBytes = input.randomAccess().get().getBitsPerPixel() / new ByteType().getBitsPerPixel();
-		
-		int[] realOffset = offset.clone();
-		realOffset[ 0 ] *= sizeInBytes;
-
-		for ( int d = 0; d < input.numDimensions(); ++d )
-		{
-			assert offset[ d ] % this.blockSize[ d ] == 0;
-			assert ( input.dimension( d ) * d == 0 ? sizeInBytes : 1 ) % this.blockSize[ d ] == 0;
-		}
-
-//		dataset.putNByteDataType( input, realOffset, sizeInBytes, writer );
-
-	}
-
-	/**
-	 * @param input
-	 *            Integer array corresponding to be adapted (will be modified).
-	 * @param blockSize
-	 *            Block size.
-	 * @return Modified input.
-	 * 
-	 *         When sending POST request to dvid, all block sizes and offsets
-	 *         need to be integral multiples of blockSize. This is a convenience
-	 *         function to modify integer arrays accordingly.
-	 */
-	public static int[] adaptToBlockSize( int[] input, final int[]blockSize )
-	{
-		for ( int d = 0; d < input.length; ++d )
-		{
-			int val = input[ d ];
-			int bs = blockSize[ d ];
-			int mod = val % bs;
-			if ( mod > 0 )
-				val += bs - mod;
-			input[ d ] = val;
-		}
-		return input;
-	}
-
-	/**
-	 * @param input
-	 *            Long array corresponding to be adapted (will be modified).
-	 * @param blockSize
-	 *            Block size.
-	 * @return Modified input.
-	 * 
-	 *         When sending POST request to dvid, all block sizes and offsets
-	 *         need to be integral multiples of blockSize. This is a convenience
-	 *         function to modify long arrays accordingly.
-	 */
-	public static long[] adaptToBlockSize( long[] input, final int[] blockSize )
-	{
-		for ( int d = 0; d < input.length; ++d )
-		{
-			long val = input[ d ];
-			int bs = blockSize[d];
-			long mod = val % bs;
-			if ( mod > 0 )
-				val += bs - mod;
-			input[ d ] = val;
-		}
-		return input;
-	}
-
+	
 	/**
 	 * This is for checking functionality. Adjust apiUrl, uuid and dataSet
 	 * according to your needs.
@@ -305,60 +118,104 @@ public class DvidNBytesWriter
 	public static void main( String[] args ) throws IOException
 	{
 
-//		// this is for testing purposes, modify apiUrl, uuid and dataSet
-//		// according to your needs
-//		// if values received from server differ from input, these values will
-//		// be printed to stdout
-//		// otherwise no output
-//
-//		String url = "http://vm570.int.janelia.org:8080";
-//		String uuid = "9c7cc44aa0544d33905ce82d153e2544";
-//		String dataSet = "bigcat-test2";
-//		
-//		Repository repo = new Repository( url, uuid );
-//
-//		Random rng = new Random();
-//
-//		int[] dim = new int[] { 200, 200, 96 };
-//		long[] longDim = new long[ dim.length ];
-//		for ( int i = 0; i < longDim.length; i++ )
-//			longDim[ i ] = dim[ i ];
-//		ArrayImg< FloatType, FloatArray > ref = ArrayImgs.floats( longDim );
-//		for ( FloatType r : ref )
-//			r.set( rng.nextFloat() );
-//
-//		DvidImage32Writer writer = new DvidImage32Writer( url, uuid, dataSet );
-//		int[] steps = new int[] { 200, 200, 32 };
-//		int[] offset = new int[] { 0, 0, 0 };
-//		Converter< FloatType, UnsignedLongType > converter = new Converter< FloatType, UnsignedLongType >()
-//		{
-//
-//			@Override
-//			public void convert( FloatType input, UnsignedLongType output )
-//			{
-//				output.set( Float.floatToIntBits( input.get() ) | 0l );
-//			}};
-//			
-//		ConvertedRandomAccessibleInterval< FloatType, UnsignedLongType > refLong = 
-//				new ConvertedRandomAccessibleInterval<FloatType,UnsignedLongType>( ref, converter, new UnsignedLongType() );
-//		writer.writeImage( refLong, steps, offset );
-//
-//		// read image from dvid server
-//		Node node = repo.getRootNode();
-//		DatasetBlkImage  ds = new DatasetBlkImage ( node, "bigcat-test2" );
-////		ArrayImg< UnsignedIntType, IntArray > target = ArrayImgs.unsignedInts( longDim );
-//		ArrayImg< UnsignedLongType, ? > target = new ArrayImgFactory<UnsignedLongType>().create( longDim, new UnsignedLongType() );
-//		ds.get( target, offset );
-//		
-//		ArrayCursor< UnsignedLongType > t = target.cursor();
-//		for ( UnsignedLongType r : Views.flatIterable( refLong ) )
-//		{
-//			long comp = r.get();
-//			long test = t.next().getIntegerLong();
-//			if ( test != comp )
-//				System.out.println( test + " " + comp );
-//		}
-//		System.out.println( "Done." );
+		// this is for testing purposes, modify apiUrl, uuid and dataSet
+		// according to your needs
+		// if values received from server differ from input, these values will
+		// be printed to stdout
+		// otherwise no output
+
+		String url = "http://vm570.int.janelia.org:8080";
+		String uuid = "4668221206e047648f622dc4690ff7dc";
+		String dataSet = "bigcat-nbyte-writer";
+		
+		Repository repo = new Repository( url, uuid );
+		
+		try
+		{
+			repo.getRootNode().createDataset( dataSet, DatasetBlkUint8.TYPE );
+		}
+		catch ( Exception e )
+		{
+			e.printStackTrace( System.err );
+		}
+		NByteIO< LongType > io = new NByteIO< LongType >()
+		{
+
+			@Override
+			public void write( LongType data, ByteBuffer bb )
+			{
+				bb.putLong( data.get() );
+			}
+
+			@Override
+			public void read( LongType data, ByteBuffer bb )
+			{
+				data.set( bb.getLong() );
+			}
+		};
+		
+		DatasetNByte< LongType > ds = new DatasetNByte< LongType >( 
+				repo.getRootNode(), 
+				dataSet, 
+				( new LongType().getBitsPerPixel() / new ByteType().getBitsPerPixel() ),
+				io );
+		
+		DvidNBytesWriter< LongType > writer = new DvidNBytesWriter< LongType >( ds );
+		
+		long[] dim = new long[] { 35, 80, 65 };
+		long[] targetDim = new long[ dim.length ];
+		int[] blockSize = new int[] { 32, 32, 32 };
+		long[] blockSizeLong = new long[] { 32, 32, 32 };
+		long[] nBlocksByDimension = new long[ 3 ];
+		for ( int  d = 0; d < dim.length; ++d )
+		{
+			long remainder = dim[ d ] % blockSize[ d ];
+			nBlocksByDimension[ d ] = dim[ d ] / blockSize[ d ] + ( remainder == 0 ? 0 : 1 );
+			targetDim[ d ] = nBlocksByDimension[ d ] * blockSize[ d ];
+		}
+		long nBlocks = DatasetNByte.product( nBlocksByDimension );
+		
+		ArrayImg< LongType, LongArray > img = ArrayImgs.longs( dim );
+		Random rng = new Random( 100 );
+		for ( LongType i : img )
+			i.set( rng.nextLong() );
+		
+		ArrayImg< LongType, LongArray > target = ArrayImgs.longs( targetDim );
+		
+		writer.writeImage( img, new int[] { 0, 0, 0 } );
+		
+		// read
+		for ( long i = 0; i < nBlocks; ++i )
+		{
+			long[] position = new long[ 3 ];
+			int[] positionInt = new int[ 3 ];
+			DatasetNByte.indexToPosition( i, nBlocksByDimension, position );
+			for ( int d = 0; d < position.length; ++d )
+			{
+				positionInt[ d ] = ( int ) position[ d ];
+				position[ d ] *= blockSize[ d ];
+			}
+			IntervalView< LongType > interval = Views.offsetInterval( target, position, blockSizeLong );
+			ds.getBlock( interval, positionInt, io );
+		}
+		
+		ArrayRandomAccess< LongType > t = target.randomAccess();
+		
+		
+		for ( Cursor< LongType > r = Views.flatIterable( img ).cursor(); r.hasNext(); )
+		{
+			long comp = r.next().get();
+			t.setPosition( r );
+			long test = t.get().get();
+			if ( test != comp )
+			{
+				Point p = new Point( r.numDimensions() );
+				p.setPosition( r );
+				System.out.println( p + " " + test + " " + comp );
+				System.exit( 9001 );
+			}
+		}
+		System.out.println( "Done." );
 	}
 
 }

--- a/src/main/java/bdv/img/dvid/DvidNBytesWriter.java
+++ b/src/main/java/bdv/img/dvid/DvidNBytesWriter.java
@@ -1,0 +1,373 @@
+package bdv.img.dvid;
+
+import java.io.IOException;
+
+import com.google.gson.JsonIOException;
+import com.google.gson.JsonSyntaxException;
+
+import bdv.util.BlockedInterval;
+import bdv.util.dvid.DatasetBlk;
+import bdv.util.dvid.DatasetBlkUint8;
+import bdv.util.dvid.Repository;
+import bdv.util.http.HttpRequest;
+import net.imglib2.Cursor;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.view.IntervalView;
+import net.imglib2.view.Views;
+
+/**
+ * @author Philipp Hanslovsky <hanslovskyp@janelia.hhmi.org>
+ * 
+ *         Write any {@link RandomAccessibleInterval} of type {@link RealType}
+ *         into an existing dvid repository/dataset.
+ *
+ */
+public class DvidNBytesWriter
+{
+
+	private final DatasetBlkUint8 dataset;
+
+	private final int[] blockSize;
+
+	/**
+	 * @param url
+	 *            Url to dvid server in the form of http://hostname:port
+	 * @param uuid
+	 *            Uuid of repository within the dvid server specified by apiUrl.
+	 *            The root node of the repository will be used for writing.
+	 * @param dataSet
+	 *            Name of the data set within the repository specified by uuid.
+	 *            This data set must be of type imageblk.
+	 * 
+	 *            This calls
+	 *            {@link DvidNBytesWriter#DvidLabels64ByteWriter(String, String, String, int)}
+	 *            with a default block size of 32.
+	 * @throws IOException 
+	 * @throws JsonIOException 
+	 * @throws JsonSyntaxException 
+	 **/
+	public DvidNBytesWriter( String url, String uuid, String dataSet )
+	{
+		this( url, uuid, dataSet, DatasetBlk.defaultBlockSize() );
+	}
+
+	/**
+	 * @param url
+	 *            Url to dvid server in the form of http://hostname:port
+	 * @param uuid
+	 *            Uuid of repository within the dvid server specified by apiUrl.
+	 *            The root node of the repository will be used for writing.
+	 * @param dataSet
+	 *            Name of the data set within the repository specified by uuid.
+	 *            This data set must be of type imageblk
+	 * @param blockSize
+	 *            Block size of the data set. Must suit block size stored in
+	 *            dvid server.
+	 * @throws IOException 
+	 * @throws JsonIOException 
+	 * @throws JsonSyntaxException 
+	 */
+	public DvidNBytesWriter( String url, String uuid, final String dataSetName, final int[] blockSize )
+	{
+		this( new DatasetBlkUint8( new Repository( url, uuid ).getRootNode(), dataSetName ), blockSize );
+	}
+	
+	public DvidNBytesWriter( DatasetBlkUint8 dataset, int[] blockSize )
+	{
+		this.dataset = dataset;
+		this.blockSize = blockSize;
+	}
+	
+	public DvidNBytesWriter( DatasetBlkUint8 dataset ) throws JsonSyntaxException, JsonIOException, IOException
+	{
+		this( dataset, dataset.getBlockSize() );
+	}
+
+	/**
+	 * @param image
+	 *            Image to be stored in dvid server.
+	 * @param iterationAxis
+	 *            Along which axis to iterate.
+	 * @param steps
+	 *            Step sizes along each axis.
+	 * @param offset
+	 *            Offset target position by offset.
+	 * 
+	 *            Write image into data set. Calls
+	 *            {@link DvidNBytesWriter#writeImage(RandomAccessibleInterval, int, int[], int[])}
+	 *            with iterationAxis set to 2.
+	 */
+	public < T extends RealType< T > > void writeImage(
+			RandomAccessibleInterval< T > image,
+			final int[] steps,
+			final int[] offset,
+			final HttpRequest.Writer< T > writer )
+	{
+		this.writeImage( image, 2, steps, offset, writer );
+	}
+
+	/**
+	 * @param image
+	 *            Image to be stored in dvid server.
+	 * @param iterationAxis
+	 *            Along which axis to iterate.
+	 * @param steps
+	 *            Step sizes along each axis.
+	 * @param offset
+	 *            Offset target position by offset.
+	 * 
+	 *            Write image into data set. Calls
+	 *            {@link DvidNBytesWriter#writeImage(RandomAccessibleInterval, int, int[], int[], RealType)}
+	 *            with borderExtension set to 0.
+	 */
+	public < T extends RealType< T > > void writeImage(
+			RandomAccessibleInterval< T > image,
+			final int iterationAxis,
+			final int[] steps,
+			final int[] offset,
+			final HttpRequest.Writer< T > writer )
+	{
+		T zeroExtension = image.randomAccess().get().createVariable();
+		zeroExtension.setZero();
+		this.writeImage( image, iterationAxis, steps, offset, writer, zeroExtension );
+	}
+
+	/**
+	 * @param image
+	 *            Image to be stored in dvid server.
+	 * @param iterationAxis
+	 *            Along which axis to iterate.
+	 * @param steps
+	 *            Step sizes along each axis.
+	 * @param offset
+	 *            Offset target position by offset.
+	 * @param borderExtension
+	 *            Extend border with this value.
+	 * 
+	 *            Write image into data set. The image will be divided into
+	 *            blocks as defined by steps. The target coordinates will be the
+	 *            image coordinates shifted by offset.
+	 */
+	public < T extends RealType< T > > void writeImage(
+			RandomAccessibleInterval< T > image,
+			final int iterationAxis,
+			final int[] steps,
+			final int[] offset,
+			final HttpRequest.Writer< T > writer,
+			T borderExtension )
+	{
+		// realX ensures that realX[i] is integer multiple of blockSize
+		long[] realDim = new long[ image.numDimensions() ];
+		image.dimensions( realDim );
+		adaptToBlockSize( realDim, this.blockSize );
+		int[] realSteps = adaptToBlockSize( steps.clone(), this.blockSize );
+		int[] realOffset = adaptToBlockSize( offset.clone(), this.blockSize );
+
+		// For now, assume always that data is in [0,1,2] == "xyz" format.
+		// Do we need flexibility to allow for different orderings?
+		int[] dims = new int[ image.numDimensions() ];
+		for ( int d = 0; d < image.numDimensions(); ++d )
+			dims[ d ] = d;
+
+		// stepSize as long[], needed for BlockedInterval
+		long[] stepSize = new long[ image.numDimensions() ];
+		for ( int i = 0; i < stepSize.length; i++ )
+			stepSize[ i ] = realSteps[ i ];
+
+		// Create BlockedInterval that allows for flat iteration and intuitive
+		// hyperslicing.
+		// Go along iterationAxis and hyperslice, then iterate over each
+		// hyperslice.
+		BlockedInterval< T > blockedImage = BlockedInterval.createZeroExtended( image, stepSize );
+		for ( int a = 0, aUnitIncrement = 0; a < image.dimension( iterationAxis ); ++aUnitIncrement, a += realSteps[ iterationAxis ] )
+		{
+			IntervalView< RandomAccessibleInterval< T >> hs = 
+					Views.hyperSlice( blockedImage, iterationAxis, aUnitIncrement );
+			Cursor< RandomAccessibleInterval< T >> cursor = Views.flatIterable( hs ).cursor();
+			while ( cursor.hasNext() )
+			{
+				RandomAccessibleInterval< T > block = cursor.next();
+				System.out.println( cursor.getLongPosition( 0 ) + " " + cursor.getLongPosition( 1 ) + " " + a );
+				int[] localOffset = realOffset.clone();
+				localOffset[ iterationAxis ] = a;
+				for ( int i = 0, k = 0; i < localOffset.length; i++ )
+				{
+					if ( i == iterationAxis )
+						continue;
+					localOffset[ i ] += cursor.getIntPosition( k++ ) * stepSize[ i ];
+				}
+				try
+				{
+					this.writeBlock( block, dims, localOffset, writer );
+				}
+				catch ( IOException e )
+				{
+					System.err.println( "Failed to write block: " + dataset.getRequestString( DatasetBlkUint8.getIntervalRequestString( image, realSteps ) ) );
+					e.printStackTrace();
+				}
+			}
+		}
+
+		return;
+	}
+
+	/**
+	 * @param input
+	 *            Block of data to be written to dvid data set.
+	 * @param dims
+	 *            Interpretation of the dimensionality of the block, e.g.
+	 *            [0,1,2] corresponds to "xyz".
+	 * @param offset
+	 *            Position of the "upper left" corner of the block within the
+	 *            dvid coordinate system.
+	 * @throws IOException
+	 * 
+	 *             Write block into dvid data set at position specified by
+	 *             offset using http POST request.
+	 */
+	public < T extends RealType< T > > void writeBlock(
+			RandomAccessibleInterval< T > input,
+			final int[] dims,
+			final int[] offset,
+			final HttpRequest.Writer< T > writer ) throws IOException
+	{
+		// Offset and block dimensions must be integer multiples of
+		// this.blockSize.
+		// For now add the asserts, maybe make this method private/protected and
+		// have
+		// enclosing method take care of it.
+		
+		int sizeInBytes = input.randomAccess().get().getBitsPerPixel() / new ByteType().getBitsPerPixel();
+		
+		int[] realOffset = offset.clone();
+		realOffset[ 0 ] *= sizeInBytes;
+
+		for ( int d = 0; d < input.numDimensions(); ++d )
+		{
+			assert offset[ d ] % this.blockSize[ d ] == 0;
+			assert ( input.dimension( d ) * d == 0 ? sizeInBytes : 1 ) % this.blockSize[ d ] == 0;
+		}
+
+		dataset.putNByteDataType( input, realOffset, sizeInBytes, writer );
+
+	}
+
+	/**
+	 * @param input
+	 *            Integer array corresponding to be adapted (will be modified).
+	 * @param blockSize
+	 *            Block size.
+	 * @return Modified input.
+	 * 
+	 *         When sending POST request to dvid, all block sizes and offsets
+	 *         need to be integral multiples of blockSize. This is a convenience
+	 *         function to modify integer arrays accordingly.
+	 */
+	public static int[] adaptToBlockSize( int[] input, final int[]blockSize )
+	{
+		for ( int d = 0; d < input.length; ++d )
+		{
+			int val = input[ d ];
+			int bs = blockSize[ d ];
+			int mod = val % bs;
+			if ( mod > 0 )
+				val += bs - mod;
+			input[ d ] = val;
+		}
+		return input;
+	}
+
+	/**
+	 * @param input
+	 *            Long array corresponding to be adapted (will be modified).
+	 * @param blockSize
+	 *            Block size.
+	 * @return Modified input.
+	 * 
+	 *         When sending POST request to dvid, all block sizes and offsets
+	 *         need to be integral multiples of blockSize. This is a convenience
+	 *         function to modify long arrays accordingly.
+	 */
+	public static long[] adaptToBlockSize( long[] input, final int[] blockSize )
+	{
+		for ( int d = 0; d < input.length; ++d )
+		{
+			long val = input[ d ];
+			int bs = blockSize[d];
+			long mod = val % bs;
+			if ( mod > 0 )
+				val += bs - mod;
+			input[ d ] = val;
+		}
+		return input;
+	}
+
+	/**
+	 * This is for checking functionality. Adjust apiUrl, uuid and dataSet
+	 * according to your needs.
+	 * 
+	 * @param args
+	 * @throws IOException
+	 */
+	public static void main( String[] args ) throws IOException
+	{
+
+//		// this is for testing purposes, modify apiUrl, uuid and dataSet
+//		// according to your needs
+//		// if values received from server differ from input, these values will
+//		// be printed to stdout
+//		// otherwise no output
+//
+//		String url = "http://vm570.int.janelia.org:8080";
+//		String uuid = "9c7cc44aa0544d33905ce82d153e2544";
+//		String dataSet = "bigcat-test2";
+//		
+//		Repository repo = new Repository( url, uuid );
+//
+//		Random rng = new Random();
+//
+//		int[] dim = new int[] { 200, 200, 96 };
+//		long[] longDim = new long[ dim.length ];
+//		for ( int i = 0; i < longDim.length; i++ )
+//			longDim[ i ] = dim[ i ];
+//		ArrayImg< FloatType, FloatArray > ref = ArrayImgs.floats( longDim );
+//		for ( FloatType r : ref )
+//			r.set( rng.nextFloat() );
+//
+//		DvidImage32Writer writer = new DvidImage32Writer( url, uuid, dataSet );
+//		int[] steps = new int[] { 200, 200, 32 };
+//		int[] offset = new int[] { 0, 0, 0 };
+//		Converter< FloatType, UnsignedLongType > converter = new Converter< FloatType, UnsignedLongType >()
+//		{
+//
+//			@Override
+//			public void convert( FloatType input, UnsignedLongType output )
+//			{
+//				output.set( Float.floatToIntBits( input.get() ) | 0l );
+//			}};
+//			
+//		ConvertedRandomAccessibleInterval< FloatType, UnsignedLongType > refLong = 
+//				new ConvertedRandomAccessibleInterval<FloatType,UnsignedLongType>( ref, converter, new UnsignedLongType() );
+//		writer.writeImage( refLong, steps, offset );
+//
+//		// read image from dvid server
+//		Node node = repo.getRootNode();
+//		DatasetBlkImage  ds = new DatasetBlkImage ( node, "bigcat-test2" );
+////		ArrayImg< UnsignedIntType, IntArray > target = ArrayImgs.unsignedInts( longDim );
+//		ArrayImg< UnsignedLongType, ? > target = new ArrayImgFactory<UnsignedLongType>().create( longDim, new UnsignedLongType() );
+//		ds.get( target, offset );
+//		
+//		ArrayCursor< UnsignedLongType > t = target.cursor();
+//		for ( UnsignedLongType r : Views.flatIterable( refLong ) )
+//		{
+//			long comp = r.get();
+//			long test = t.next().getIntegerLong();
+//			if ( test != comp )
+//				System.out.println( test + " " + comp );
+//		}
+//		System.out.println( "Done." );
+	}
+
+}

--- a/src/main/java/bdv/labels/labelset/DownscalingVolatileSuperVoxelMultisetArrayLoaderDvid.java
+++ b/src/main/java/bdv/labels/labelset/DownscalingVolatileSuperVoxelMultisetArrayLoaderDvid.java
@@ -51,8 +51,10 @@ public class DownscalingVolatileSuperVoxelMultisetArrayLoaderDvid implements Cac
 			return cached;
 
 		final RandomAccessibleInterval< SuperVoxelMultisetType > input = multisetSource.getSource( timepoint, level - 1 );
-		final int[] factors = new int[] { 2, 2, 2 };
-		return downscale( input, factors, dimensions, min, store, key );
+		final int[] factors = new int[] { 2, 2, 2 }; // for now 2,2,2
+		int strideByDimension = 1 << ( level - 1 ); // need to get the stride of previous (aka input) level
+		int nElementsPerInputPixel = strideByDimension * strideByDimension * strideByDimension;
+		return downscale( input, factors, dimensions, min, store, key, nElementsPerInputPixel );
 	}
 
 	@Override
@@ -138,7 +140,8 @@ public class DownscalingVolatileSuperVoxelMultisetArrayLoaderDvid implements Cac
 			final int[] dimensions,
 			final long[] min,
 			final DatasetKeyValue store,
-			final String key ) throws InterruptedException
+			final String key,
+			final int nElementsPerInputPixel ) throws InterruptedException
 	{
 		final int n = 3;
 		final int[] data = new int[ dimensions[ 0 ] * dimensions[ 1 ] * dimensions[ 2 ] ];
@@ -151,8 +154,6 @@ public class DownscalingVolatileSuperVoxelMultisetArrayLoaderDvid implements Cac
 		int numContribs = 1;
 		for ( int i = 0; i < n; ++i )
 			numContribs *= factors[ i ];
-
-		final int finalNumContribs = numContribs;
 
 		@SuppressWarnings( "unchecked" )
 		final RandomAccess< SuperVoxelMultisetType >[] inputs = new RandomAccess[ numContribs ];
@@ -226,7 +227,7 @@ public class DownscalingVolatileSuperVoxelMultisetArrayLoaderDvid implements Cac
 										@Override
 										public int getCount()
 										{
-											return finalNumContribs;
+											return nElementsPerInputPixel;
 										}
 									};
 								}

--- a/src/main/java/bdv/labels/labelset/DownscalingVolatileSuperVoxelMultisetArrayLoaderDvid.java
+++ b/src/main/java/bdv/labels/labelset/DownscalingVolatileSuperVoxelMultisetArrayLoaderDvid.java
@@ -44,16 +44,31 @@ public class DownscalingVolatileSuperVoxelMultisetArrayLoaderDvid implements Cac
 //				);
 //		final String filename = getFilename( timepoint, setup, level, min );
 		// level 0 does not have an associated data set, thus need to subtract 1
+		RandomAccessibleInterval< SuperVoxelMultisetType > source = multisetSource.getSource( timepoint, level );
+
+		int strideByDimensionSource = 1 << level;
+		int nElementsPerSource = strideByDimensionSource * strideByDimensionSource * strideByDimensionSource;
+
+		if (
+				// TODO Adapt if source dimensions are corrected (right now, it's the dimension of the
+				// highest resolution source).
+				min[ 0 ] * strideByDimensionSource > source.max( 0 ) || min[ 1 ] * strideByDimensionSource > source.max( 1 ) || min[ 2 ] * strideByDimensionSource > source.max( 2 ) ||
+				min[ 0 ] < 0 /* source.min( 0 ) */ || min[ 1 ] < 0 /* source.min( 1 ) */ || min[ 2 ] < 0 /* source.min( 2 ) */
+			)
+		{
+			return createOutOfBoundsOnlyZeros( dimensions, nElementsPerSource );
+		}
+
 		DatasetKeyValue store = dvidStores[ level - 1 ]; // -1? TODO
-		String key = getKey( timepoint, setup, min ); 
+		String key = getKey( timepoint, setup, min );
 		final VolatileSuperVoxelMultisetArray cached = tryLoadCached( dimensions, store, key );
 		if ( cached != null )
 			return cached;
 
+		int strideByDimensionInput = 1 << ( level - 1 ); // need to get the stride of previous (aka input) level
+		int nElementsPerInputPixel = strideByDimensionInput * strideByDimensionInput * strideByDimensionInput;
 		final RandomAccessibleInterval< SuperVoxelMultisetType > input = multisetSource.getSource( timepoint, level - 1 );
 		final int[] factors = new int[] { 2, 2, 2 }; // for now 2,2,2
-		int strideByDimension = 1 << ( level - 1 ); // need to get the stride of previous (aka input) level
-		int nElementsPerInputPixel = strideByDimension * strideByDimension * strideByDimension;
 		return downscale( input, factors, dimensions, min, store, key, nElementsPerInputPixel );
 	}
 
@@ -185,6 +200,7 @@ public class DownscalingVolatileSuperVoxelMultisetArrayLoaderDvid implements Cac
 				// TODO Why does this fail, when inputPos[ d ] > input.dimension( d )?
 				// Add super voxel with label zero and count numContribs if out of bounds value
 				// is requested. This is a workaround to achieve zero-extension of the input.
+				// Need to consider that input min and max are actually min and max of original resolution
 				if (
 						inputPos[ 0 ] > input.max( 0 ) || inputPos[ 1 ] > input.max( 1 ) || inputPos[ 2 ] > input.max( 2 ) ||
 						inputPos[ 0 ] < input.min( 0 ) || inputPos[ 1 ] < input.min( 1 ) || inputPos[ 2 ] < input.min( 2 )
@@ -338,5 +354,21 @@ public class DownscalingVolatileSuperVoxelMultisetArrayLoaderDvid implements Cac
 		if ( theEmptyArray.getCurrentStorageArray().length < numEntities )
 			theEmptyArray = new VolatileSuperVoxelMultisetArray( numEntities, false );
 		return theEmptyArray;
+	}
+
+	private VolatileSuperVoxelMultisetArray createOutOfBoundsOnlyZeros( int[] dimensions, int nElementsPerSource )
+	{
+		final int nElements = dimensions[ 0 ] * dimensions[ 1 ] * dimensions[ 2 ];
+		final int[] data = new int[ nElements ];
+		final int listDataSize = 16 * nElements;
+		final LongMappedAccessData listData = LongMappedAccessData.factory.createStorage( listDataSize );
+		for ( int i = 0, dataIndex = 0; dataIndex < nElements; i += 16, ++dataIndex )
+		{
+			ByteUtils.putInt( 1, listData.data, i );
+			ByteUtils.putLong( 0l, listData.data, i + 4 );
+			ByteUtils.putInt( nElementsPerSource, listData.data, i + 12 );
+			data[ dataIndex ] = i;
+		}
+		return new VolatileSuperVoxelMultisetArray( data, listData, true );
 	}
 }

--- a/src/main/java/bdv/labels/labelset/DvidLabels64MultisetSetupImageLoader.java
+++ b/src/main/java/bdv/labels/labelset/DvidLabels64MultisetSetupImageLoader.java
@@ -37,7 +37,7 @@ public class DvidLabels64MultisetSetupImageLoader
 
 	private final VolatileSuperVoxelMultisetArrayLoader loader;
 
-	public final DownscalingVolatileSuperVoxelMultisetArrayLoaderDvid downscaleLoader;
+	private final DownscalingVolatileSuperVoxelMultisetArrayLoaderDvid downscaleLoader;
 
 	private final int setupId;
 
@@ -200,4 +200,9 @@ public class DvidLabels64MultisetSetupImageLoader
 	{
 		return setupId;
 	};
+
+	public VolatileSuperVoxelMultisetArray loadArray( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException
+	{
+		return this.downscaleLoader.loadArray( timepoint, setup, level, dimensions, min );
+	}
 }

--- a/src/main/java/bdv/labels/labelset/DvidLabels64MultisetSetupImageLoader.java
+++ b/src/main/java/bdv/labels/labelset/DvidLabels64MultisetSetupImageLoader.java
@@ -37,7 +37,7 @@ public class DvidLabels64MultisetSetupImageLoader
 
 	private final VolatileSuperVoxelMultisetArrayLoader loader;
 
-	private final DownscalingVolatileSuperVoxelMultisetArrayLoaderDvid downscaleLoader;
+	public final DownscalingVolatileSuperVoxelMultisetArrayLoaderDvid downscaleLoader;
 
 	private final int setupId;
 

--- a/src/main/java/bdv/util/dvid/DatasetBlk.java
+++ b/src/main/java/bdv/util/dvid/DatasetBlk.java
@@ -25,7 +25,7 @@ public abstract class DatasetBlk< T > extends Dataset
 	{
 		super( node, name, type );
 	}
-	
+
 	/**
 	 * @param target {@link RandomAccessibleInterval} to be written into.
 	 * @param offset Specifies top left position of target within the dataset.
@@ -39,7 +39,7 @@ public abstract class DatasetBlk< T > extends Dataset
 			RandomAccessibleInterval< T > target,
 			int[] offset
 			) throws MalformedURLException, IOException;
-	
+
 	/**
 	 * @param source {@link RandomAccessibleInterval} to be read from.
 	 * @param offset Specifies top left position of source within the dataset.
@@ -64,49 +64,94 @@ public abstract class DatasetBlk< T > extends Dataset
 	{
 		return getRequestString( getIntervalRequestString( image, offset ) );
 	}
-	
-	
+
 	/**
 	 * @param min Pixel contained in block to be retrieved.
-	 * @param blockSize Size of blocks in data set. 
+	 * @param blockSize Size of blocks in data set.
+	 * @param nBlocks Number of blocks along X coordinate.
 	 * @return Appropriate url to retrieve block that contains pixel
 	 * defined by min.
 	 */
-	public String getBlockRequestUrl( int[] min, int[] blockSize )
+	public String getBlockRequestUrl( int[] min, int[] blockSize, int nBlocks )
 	{
-		return getRequestString( getBlockRequestString( min, blockSize ) );
+		return getRequestString( getBlockRequestString( min, blockSize, nBlocks ) );
 	}
-	
+
+	/**
+	 * @param position Coordinates of block (e.g. for block size [32, 32, 32],
+	 * the top left corner of the block identified by position [1, 2, 3] is at
+	 * [32, 64, 96] in real world coordinates).
+	 * @param nBlocks Number of blocks along X coordinate.
+	 * @return Appropriate url to retrieve block defined by position.
+	 */
+	public String getBlockRequestUrl( int[] position, int nBlocks )
+	{
+		return getRequestString( getBlockRequestString( position, nBlocks ) );
+	}
+
 	/**
 	 * @param min Pixel contained in block to be retrieved.
 	 * @param blockSize Size of blocks in data set.  
+	 * @param nBlocks Number of blocks along X coordinate.
 	 * @return Request String to retrieve block that contains pixel
 	 * defined by min.
 	 */
-	public static String getBlockRequestString( int[] min, int[] blockSize )
+	public static String getBlockRequestString( int[] min, int[] blockSize, int nBlocks )
 	{
-		StringBuffer buf = new StringBuffer( "/blocks/" )
-			.append( min[ 0 ] / blockSize[ 0 ] )
+		int[] position = new int[] {
+				min[ 0 ] / blockSize[ 0 ],
+				min[ 1 ] / blockSize[ 1 ],
+				min[ 2 ] / blockSize[ 2 ]
+		};
+		return getBlockRequestString( position, nBlocks );
+	}
+
+	/**
+	 * @param position Coordinates of block (e.g. for block size [32, 32, 32],
+	 * the top left corner of the block identified by position [1, 2, 3] is at
+	 * [32, 64, 96] in real world coordinates). 
+	 * @param nBlocks Number of blocks along X coordinate.
+	 * @return Request String to retrieve block Appropriate url to retrieve block defined by position.
+	 */
+	public static String getBlockRequestString( int[] position, int nBlocks )
+	{
+		StringBuffer buf = new StringBuffer( "blocks/" )
+			.append( position[0] )
 			.append( "_" )
-			.append( min[ 1 ] / blockSize[ 1 ] )
+			.append( position[1] )
 			.append( "_" )
-			.append( min[ 2 ] / blockSize[ 2 ] )
-			.append( "/1" )
+			.append( position[2] )
+			.append( "/" )
+			.append( nBlocks )
 			;
 		return buf.toString();
 	}
-	
+
 	/**
 	 * @param min Pixel contained in block to be retrieved.
-	 * @param blockSize Size of blocks in data set.  
+	 * @param blockSize Size of blocks in data set.
+	 * @param nBlocks Number of blocks along X coordinate.
 	 * @return Block as byte[] that contains pixel defined by min.
 	 */
-	public byte[] getBlock( int[] min, int[] blockSize ) throws MalformedURLException, IOException
+	public byte[] getBlock( int[] min, int[] blockSize, int nBlocks ) throws MalformedURLException, IOException
 	{
-		String requestUrl = getBlockRequestUrl( min, blockSize );
+		String requestUrl = getBlockRequestUrl( min, blockSize, nBlocks );
 		return HttpRequest.getRequest( requestUrl );
 	}
-	
+
+	/**
+	 * @param position Coordinates of block (e.g. for block size [32, 32, 32],
+	 * the top left corner of the block identified by position [1, 2, 3] is at
+	 * [32, 64, 96] in real world coordinates).
+	 * @param nBlocks Number of blocks along X coordinate.
+	 * @return Block as byte[] defined by position.
+	 */
+	public byte[] getBlock( int[] position, int nBlocks ) throws MalformedURLException, IOException
+	{
+		String requestUrl = getBlockRequestUrl( position, nBlocks );
+		return HttpRequest.getRequest( requestUrl );
+	}
+
 	/**
 	 * @param image Defines image dimensions.
 	 * @param offset Defines image position.
@@ -125,7 +170,7 @@ public abstract class DatasetBlk< T > extends Dataset
 				;
 		return requestString.toString();
 	}
-	
+
 	/**
 	 * @param image Defines image dimensions.
 	 * @param result Store result within this array.
@@ -141,7 +186,7 @@ public abstract class DatasetBlk< T > extends Dataset
 		String requestUrl = getRequestString( getIntervalRequestString( interval, offset ) );
 		HttpRequest.getRequest( requestUrl, result );
 	}
-	
+
 	/**
 	 * @return Block size of this data set.
 	 * @throws JsonSyntaxException
@@ -154,7 +199,7 @@ public abstract class DatasetBlk< T > extends Dataset
 		getBlockSize( blockSize );
 		return blockSize;
 	}
-	
+
 	/**
 	 * @param blockSize Write block size of this data set into this array.
 	 * @throws JsonSyntaxException
@@ -167,7 +212,7 @@ public abstract class DatasetBlk< T > extends Dataset
 		for ( int d = 0; d < bs.size(); ++d )
 			blockSize[ d ] = bs.get( d  ).getAsInt();
 	}
-	
+
 	/**
 	 * @return Default block size for blocked data sets.
 	 */
@@ -175,5 +220,5 @@ public abstract class DatasetBlk< T > extends Dataset
 	{
 		return new int[] { 32, 32, 32 };
 	}
-			
+
 }

--- a/src/main/java/bdv/util/dvid/DatasetBlk.java
+++ b/src/main/java/bdv/util/dvid/DatasetBlk.java
@@ -20,10 +20,13 @@ import net.imglib2.RandomAccessibleInterval;
  */
 public abstract class DatasetBlk< T > extends Dataset
 {
+	
+	protected final int[] blockSize;
 
-	public DatasetBlk( Node node, String name, String type )
+	public DatasetBlk( Node node, String name, String type ) throws JsonSyntaxException, JsonIOException, IOException
 	{
 		super( node, name, type );
+		this.blockSize = getBlockSize();
 	}
 
 	/**
@@ -53,6 +56,10 @@ public abstract class DatasetBlk< T > extends Dataset
 			RandomAccessibleInterval< T > source,
 			int[] offset
 			) throws MalformedURLException, IOException;
+	
+	public abstract void writeBlock( 
+			RandomAccessibleInterval< T > source, 
+			int[] position ) throws MalformedURLException, IOException;
 	
 	/**
 	 * @param image Defines image dimensions.

--- a/src/main/java/bdv/util/dvid/DatasetBlkLabel.java
+++ b/src/main/java/bdv/util/dvid/DatasetBlkLabel.java
@@ -4,6 +4,9 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.nio.ByteBuffer;
 
+import com.google.gson.JsonIOException;
+import com.google.gson.JsonSyntaxException;
+
 import bdv.util.http.HttpRequest;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.integer.UnsignedLongType;
@@ -19,7 +22,7 @@ public class DatasetBlkLabel extends DatasetBlk< UnsignedLongType >
 {
 	public static String TYPE = "labelblk";
 
-	public DatasetBlkLabel( Node node, String name )
+	public DatasetBlkLabel( Node node, String name ) throws JsonSyntaxException, JsonIOException, IOException
 	{
 		super( node, name, TYPE );
 	}
@@ -51,5 +54,10 @@ public class DatasetBlkLabel extends DatasetBlk< UnsignedLongType >
 		
 	}
 
+	@Override
+	public void writeBlock( RandomAccessibleInterval< UnsignedLongType > source, int[] position ) throws MalformedURLException, IOException
+	{
+		throw new UnsupportedOperationException( "Datatype labelblk currently does not support /blocks/ api." );
+	}
 
 }

--- a/src/main/java/bdv/util/dvid/DatasetBlkRGBA.java
+++ b/src/main/java/bdv/util/dvid/DatasetBlkRGBA.java
@@ -4,7 +4,11 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.nio.ByteBuffer;
 
+import com.google.gson.JsonIOException;
+import com.google.gson.JsonSyntaxException;
+
 import bdv.util.http.HttpRequest;
+import net.imglib2.Cursor;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.integer.UnsignedIntType;
 import net.imglib2.view.Views;
@@ -20,9 +24,15 @@ public class DatasetBlkRGBA extends DatasetBlk< UnsignedIntType >
 	
 	public static final String TYPE = "rgba8blk";
 	
-	public DatasetBlkRGBA( Node node, String name )
+	private final byte[] buffer;
+	
+	public DatasetBlkRGBA( Node node, String name ) throws JsonSyntaxException, JsonIOException, IOException
 	{
 		super( node, name, TYPE );
+		int nEntitiesPerBlock = Integer.BYTES;
+		for ( int d = 0; d < this.blockSize.length; ++d )
+			nEntitiesPerBlock *= this.blockSize[ d ];
+		this.buffer = new byte[ nEntitiesPerBlock ];
 	}
 
 	@Override
@@ -50,6 +60,22 @@ public class DatasetBlkRGBA extends DatasetBlk< UnsignedIntType >
 		for( UnsignedIntType t : Views.flatIterable( target ) )
 			t.setInteger( bb.getInt() );
 		
+	}
+
+	@Override
+	public void writeBlock( RandomAccessibleInterval< UnsignedIntType > source, int[] position ) throws MalformedURLException, IOException
+	{
+		for ( int d = 0; d < blockSize.length; ++d )
+			assert source.dimension( d ) == blockSize[ d ];
+		
+		Cursor< UnsignedIntType > cursor = Views.flatIterable( source ).cursor();
+		ByteBuffer bb = ByteBuffer.wrap( this.buffer );
+		while( cursor.hasNext() )
+		{
+			bb.putInt( cursor.next().getInteger() );
+		}
+		String url = getBlockRequestUrl( position, 1 );
+		HttpRequest.postRequest( url, this.buffer );
 	}
 
 }

--- a/src/main/java/bdv/util/dvid/DatasetBlkUint8.java
+++ b/src/main/java/bdv/util/dvid/DatasetBlkUint8.java
@@ -4,7 +4,11 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.nio.ByteBuffer;
 
+import com.google.gson.JsonIOException;
+import com.google.gson.JsonSyntaxException;
+
 import bdv.util.http.HttpRequest;
+import net.imglib2.Cursor;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
 import net.imglib2.view.Views;
@@ -20,9 +24,15 @@ public class DatasetBlkUint8 extends DatasetBlk< UnsignedByteType >
 	
 	public static final String TYPE = "uint8blk";
 	
-	public DatasetBlkUint8( Node node, String name )
+	private final byte[] buffer;
+	
+	public DatasetBlkUint8( Node node, String name ) throws JsonSyntaxException, JsonIOException, IOException
 	{
 		super( node, name, TYPE );
+		int nEntitiesPerBlock = Byte.BYTES;
+		for ( int d = 0; d < this.blockSize.length; ++d )
+			nEntitiesPerBlock *= this.blockSize[ d ];
+		this.buffer = new byte[ nEntitiesPerBlock ];
 	}
 
 	@Override
@@ -49,5 +59,21 @@ public class DatasetBlkUint8 extends DatasetBlk< UnsignedByteType >
 		ByteBuffer bb = ByteBuffer.wrap( data );
 		for( UnsignedByteType t : Views.flatIterable( target ) )
 			t.setInteger( bb.get() );
+	}
+
+	@Override
+	public void writeBlock( RandomAccessibleInterval< UnsignedByteType > source, int[] position ) throws MalformedURLException, IOException
+	{
+		for ( int d = 0; d < blockSize.length; ++d )
+			assert source.dimension( d ) == blockSize[ d ];
+		
+		Cursor< UnsignedByteType > cursor = Views.flatIterable( source ).cursor();
+		ByteBuffer bb = ByteBuffer.wrap( this.buffer );
+		while( cursor.hasNext() )
+		{
+			bb.put( (byte) ( cursor.next().get() & 0xff ) );
+		}
+		String url = getBlockRequestUrl( position, 1 );
+		HttpRequest.postRequest( url, this.buffer );
 	}
 }

--- a/src/main/java/bdv/util/dvid/DatasetBlkUint8.java
+++ b/src/main/java/bdv/util/dvid/DatasetBlkUint8.java
@@ -1,10 +1,15 @@
 package bdv.util.dvid;
 
+import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.nio.ByteBuffer;
 
 import bdv.util.http.HttpRequest;
+import bdv.util.http.HttpRequest.Writer;
+import net.imglib2.FinalInterval;
+import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
 import net.imglib2.view.Views;
@@ -18,6 +23,55 @@ import net.imglib2.view.Views;
 public class DatasetBlkUint8 extends DatasetBlk< UnsignedByteType >
 {
 	
+	public static interface NByteResponseHandler< T > extends HttpRequest.ResponseHandler
+	{
+		public Interval getInterval();
+	}
+
+	public static abstract class RandomAccessibleNByteResponseHandler< T > implements NByteResponseHandler< T >
+	{
+
+		private final RandomAccessibleInterval< T > target;
+
+		private final int nBytes;
+
+		RandomAccessibleNByteResponseHandler( final RandomAccessibleInterval< T > target, final int nBytes )
+		{
+			this.target = target;
+			this.nBytes = nBytes;
+		}
+
+		public Interval getInterval()
+		{
+			return target;
+		}
+
+		@Override
+		public void handle( InputStream in ) throws IOException
+		{
+			int size = nBytes;
+			for ( int d = 0; d < target.numDimensions(); ++d )
+				size *= target.dimension( d );
+			byte[] data = new byte[ size ];
+			int off = 0, l = 0;
+			do
+			{
+				l = in.read( data, off, data.length - off );
+				off += l;
+			}
+			while ( l > 0 && off < data.length );
+
+			ByteBuffer bb = ByteBuffer.wrap( data );
+			for ( T t : Views.flatIterable( target ) )
+			{
+				getNext( bb, t );
+			}
+		}
+
+		abstract protected void getNext( ByteBuffer bb, T target );
+
+	}
+
 	public static final String TYPE = "uint8blk";
 	
 	public DatasetBlkUint8( Node node, String name )
@@ -36,6 +90,33 @@ public class DatasetBlkUint8 extends DatasetBlk< UnsignedByteType >
 				Views.flatIterable( source ), "application/octet-stream" );
 	}
 
+	public < T > void putNByteDataType(
+			final RandomAccessibleInterval< T > source,
+			final int[] offset,
+			final int sizeInBytes,
+			HttpRequest.Writer< T > pixelWriter
+			) throws MalformedURLException, IOException
+	{
+
+		long[] dimensions = new long[ source.numDimensions() ];
+		source.dimensions( dimensions );
+		dimensions[ 0 ] *= sizeInBytes;
+		FinalInterval interval = new FinalInterval( dimensions );
+
+		Writer< RandomAccessibleInterval< T > > writer = new HttpRequest.Writer< RandomAccessibleInterval< T > >()
+		{
+
+			@Override
+			public void write( DataOutputStream out, RandomAccessibleInterval< T > data ) throws IOException
+			{
+				for ( T d : Views.flatIterable( data ) )
+					pixelWriter.write( out, d );
+			}
+		};
+
+		HttpRequest.postRequest( getIntervalRequestUrl( interval, offset ), source, "application/octet-stream", writer );
+	}
+
 	@Override
 	public void get( RandomAccessibleInterval< UnsignedByteType > target, int[] offset ) throws MalformedURLException, IOException
 	{
@@ -49,6 +130,21 @@ public class DatasetBlkUint8 extends DatasetBlk< UnsignedByteType >
 		ByteBuffer bb = ByteBuffer.wrap( data );
 		for( UnsignedByteType t : Views.flatIterable( target ) )
 			t.setInteger( bb.get() );
+	}
+
+	public < T > void getNByteDataType(
+			NByteResponseHandler< T > target,
+			final int[] offset,
+			final int sizeInBytes
+			) throws MalformedURLException, IOException
+	{
+		Interval targetInterval = target.getInterval();
+		long[] dimensions = new long[ targetInterval.numDimensions() ];
+		targetInterval.dimensions( dimensions );
+		dimensions[ 0 ] *= sizeInBytes;
+		FinalInterval interval = new FinalInterval( dimensions );
+
+		HttpRequest.getRequest( getIntervalRequestUrl( interval, offset ), target );
 		
 	}
 

--- a/src/main/java/bdv/util/dvid/DatasetNByte.java
+++ b/src/main/java/bdv/util/dvid/DatasetNByte.java
@@ -1,0 +1,262 @@
+package bdv.util.dvid;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.nio.ByteBuffer;
+import java.util.Random;
+
+import com.google.gson.JsonIOException;
+import com.google.gson.JsonSyntaxException;
+
+import bdv.util.http.HttpRequest;
+import net.imglib2.Cursor;
+import net.imglib2.Point;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.array.ArrayCursor;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.array.ArrayRandomAccess;
+import net.imglib2.img.basictypeaccess.array.LongArray;
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.type.numeric.integer.LongType;
+import net.imglib2.view.ExtendedRandomAccessibleInterval;
+import net.imglib2.view.IntervalView;
+import net.imglib2.view.Views;
+
+public class DatasetNByte< T > extends DatasetBlk< T >
+{
+	
+	public static interface NByteToBuffer< U >
+	{
+		public void write( U data, ByteBuffer bb );
+		
+		public void read( U data, ByteBuffer bb );
+	}
+	
+	public static final String TYPE = "nbyte";
+	
+	private final int nBytes;
+	
+	private final int[] blockSize;
+	
+	private final int numByteBlocks;
+	
+	private final byte[] buffer;
+	
+	public DatasetNByte( Node node, String name, int nBytes ) throws JsonSyntaxException, JsonIOException, IOException
+	{
+		super( node, name, TYPE );
+		this.nBytes = nBytes;
+		this.blockSize = getBlockSize();
+		assert nBytes <= this.blockSize[ 0 ] : "Currently, size limit is data of size 32 bytes";
+		assert this.blockSize[ 0 ] % nBytes == 0;
+		this.numByteBlocks = this.nBytes; // this.blockSize[ 0 ] / this.nBytes; 
+		this.buffer = new byte[ product( this.blockSize ) ];
+	}
+
+	@Override
+	public void get( RandomAccessibleInterval< T > target, int[] offset ) throws MalformedURLException, IOException
+	{
+		throw new UnsupportedOperationException( "Can only write blocks with arbitrary size" );
+	}
+
+	@Override
+	public void put( RandomAccessibleInterval< T > source, int[] offset ) throws MalformedURLException, IOException
+	{
+		throw new UnsupportedOperationException( "Can only read blocks with arbitrary size" );
+	}
+	
+	public void writeBlock( 
+			RandomAccessibleInterval< T > source, 
+			int[] position,
+			NByteToBuffer< T > writer ) throws MalformedURLException, IOException
+	{
+		for ( int d = 0; d < blockSize.length; ++d )
+			assert source.dimension( d ) == blockSize[ d ];
+		
+		int[] correctedPosition = correctPosition( position.clone() );
+		Cursor< T > cursor = Views.flatIterable( source ).cursor();
+		for( int i = 0; i < this.numByteBlocks; ++i, ++correctedPosition[ 0 ] )
+		{
+			ByteBuffer bb = ByteBuffer.wrap( this.buffer );
+			for( int k = 0; k < this.buffer.length; k += this.nBytes )
+			{
+				writer.write( cursor.next(), bb );
+			}
+			String url = getBlockRequestUrl( correctedPosition, 1 );
+			HttpRequest.postRequest( url, this.buffer );
+		}
+		
+	}
+	
+	public void getBlock( 
+			RandomAccessibleInterval< T > target,
+			int[] position,
+			NByteToBuffer< T > reader ) throws MalformedURLException, IOException
+	{
+		for ( int d = 0; d < blockSize.length; ++d )
+			assert target.dimension( d ) == blockSize[ d ];
+		
+		int[] correctedPosition = correctPosition( position.clone() );
+		Cursor< T > cursor = Views.flatIterable( target ).cursor();
+		for( int i = 0; i < this.numByteBlocks; ++i, ++correctedPosition[ 0 ] )
+		{
+			String url = getBlockRequestUrl( correctedPosition, 1 );
+			HttpRequest.getRequest( url, buffer );
+			
+			ByteBuffer bb = ByteBuffer.wrap( this.buffer );
+			
+			for( int k = 0; k < this.buffer.length; k += this.nBytes )
+			{
+				reader.read( cursor.next(), bb );
+			}
+			
+		}
+	}
+	
+	protected int[] correctPosition( int[] position )
+	{
+		position[ 0 ] *= this.numByteBlocks;
+		return position;
+	}
+	
+	public static int product( int[] array )
+	{
+		int result = 1;
+		for( int a : array )
+			result *= a;
+		return result;
+	}
+	
+	public static long product( long[] array )
+	{
+		long result = 1;
+		for( long a : array )
+			result *= a;
+		return result;
+	}
+	
+	final static public void indexToPosition( long index, final long[] dimensions, final long[] position )
+	{
+		final int maxDim = dimensions.length - 1;
+		for ( int d = 0; d < maxDim; ++d )
+		{
+			final long j = index / dimensions[ d ];
+			position[ d ] = index - j * dimensions[ d ];
+			index = j;
+		}
+		position[ maxDim ] = index;
+	}
+	
+	public static void main( String[] args ) throws JsonSyntaxException, JsonIOException, IOException
+	{
+		
+		String url = "http://vm570.int.janelia.org:8080";
+		String uuid = "4668221206e047648f622dc4690ff7dc";
+		String dataSet = "bigcat-nbyte-2";
+		
+		Repository repo = new Repository( url, uuid );
+		
+		try
+		{
+			repo.getRootNode().createDataset( dataSet, DatasetBlkUint8.TYPE );
+		}
+		catch ( Exception e )
+		{
+			// TODO Auto-generated catch block
+			e.printStackTrace( System.err );
+		}
+		
+		DatasetNByte< LongType > ds = new DatasetNByte< LongType >( 
+				repo.getRootNode(), 
+				dataSet, 
+				( new LongType().getBitsPerPixel() / new ByteType().getBitsPerPixel() ) );
+		
+		NByteToBuffer< LongType > io = new NByteToBuffer< LongType >()
+		{
+
+			@Override
+			public void write( LongType data, ByteBuffer bb )
+			{
+				bb.putLong( data.get() );
+			}
+
+			@Override
+			public void read( LongType data, ByteBuffer bb )
+			{
+				data.set( bb.getLong() );
+			}
+		};
+		
+		long[] dim = new long[] { 35, 80, 65 };
+		long[] targetDim = new long[ dim.length ];
+		int[] blockSize = new int[] { 32, 32, 32 };
+		long[] blockSizeLong = new long[] { 32, 32, 32 };
+		long[] nBlocksByDimension = new long[ 3 ];
+		for ( int  d = 0; d < dim.length; ++d )
+		{
+			long remainder = dim[ d ] % blockSize[ d ];
+			nBlocksByDimension[ d ] = dim[ d ] / blockSize[ d ] + ( remainder == 0 ? 0 : 1 );
+			targetDim[ d ] = nBlocksByDimension[ d ] * blockSize[ d ];
+		}
+		long nBlocks = product( nBlocksByDimension );
+		
+		ArrayImg< LongType, LongArray > img = ArrayImgs.longs( dim );
+		Random rng = new Random( 100 );
+		for ( LongType i : img )
+			i.set( rng.nextLong() );
+		
+		ArrayImg< LongType, LongArray > target = ArrayImgs.longs( targetDim );
+		
+		ExtendedRandomAccessibleInterval< LongType, ArrayImg< LongType, LongArray > > extended = Views.extendZero( img );
+		
+		// write
+		for ( long i = 0; i < nBlocks; ++i )
+		{
+			long[] position = new long[ 3 ];
+			int[] positionInt = new int[ 3 ];
+			indexToPosition( i, nBlocksByDimension, position );
+			for ( int d = 0; d < position.length; ++d )
+			{
+				positionInt[ d ] = ( int ) position[ d ];
+				position[ d ] *= blockSize[ d ];
+			}
+			IntervalView< LongType > interval = Views.offsetInterval( extended, position, blockSizeLong );
+			ds.writeBlock( interval, positionInt, io );
+		}
+		
+		// read
+		for ( long i = 0; i < nBlocks; ++i )
+		{
+			long[] position = new long[ 3 ];
+			int[] positionInt = new int[ 3 ];
+			indexToPosition( i, nBlocksByDimension, position );
+			for ( int d = 0; d < position.length; ++d )
+			{
+				positionInt[ d ] = ( int ) position[ d ];
+				position[ d ] *= blockSize[ d ];
+			}
+			IntervalView< LongType > interval = Views.offsetInterval( target, position, blockSizeLong );
+			ds.getBlock( interval, positionInt, io );
+		}
+		
+		ArrayCursor< LongType > cursor = img.cursor();
+		ArrayRandomAccess< LongType > ra = target.randomAccess();
+		while( cursor.hasNext() )
+		{
+			cursor.fwd();
+			ra.setPosition( cursor );
+			LongType ref = cursor.get();
+			LongType comp = ra.get();
+			if( comp.get() != ref.get() )
+			{
+				Point p = new Point( cursor.numDimensions() );
+				p.setPosition( cursor );
+				System.out.println( p + " " + ref.get() + " " + comp.get() );
+				System.exit( 9001 );
+			}
+		}
+	System.out.println( "Done." );	
+	}
+	
+}

--- a/src/main/java/bdv/util/http/HttpRequest.java
+++ b/src/main/java/bdv/util/http/HttpRequest.java
@@ -224,6 +224,16 @@ public class HttpRequest
 		return bytes;
 	}
 	
+	public static void getRequest( String url, ResponseHandler handler ) throws MalformedURLException, IOException
+	{
+		HttpURLConnection connection = ( HttpURLConnection ) new URL( url ).openConnection();
+		int response = connection.getResponseCode();
+		if ( response != 200 )
+			throw new HTTPException( response );
+		getRequest( connection, handler );
+		connection.disconnect();
+	}
+
 	/**
 	 * Handle GET request as specified by handler.
 	 * 

--- a/src/main/java/bdv/util/http/HttpRequest.java
+++ b/src/main/java/bdv/util/http/HttpRequest.java
@@ -255,6 +255,21 @@ public class HttpRequest
 	 * 
 	 * @param url Url for request. 
 	 * @param postData Data to be posted
+	 * @throws MalformedURLException
+	 * @throws IOException
+	 */
+	public static void postRequest( String url, byte[] postData ) throws MalformedURLException, IOException
+	{
+		postRequest( url, postData, "application/octet-stream" );
+	}
+	
+	/**
+	 * 
+	 * HTTP POST request:
+	 * POST url
+	 * 
+	 * @param url Url for request. 
+	 * @param postData Data to be posted
 	 * @param contentType Value of the header field "Content-Type"
 	 * @throws MalformedURLException
 	 * @throws IOException
@@ -280,6 +295,25 @@ public class HttpRequest
 	{
 		HttpURLConnection connection = postRequestWithResponse( url, postData, contentType );
 		connection.disconnect();
+	}
+	
+	/**
+	 * 
+	 * HTTP POST request:
+	 * POST url
+	 * 
+	 * The connection is returned to allow the caller to handle a potential response.
+	 * The caller is responsible for closing the connection.
+	 * 
+	 * @param url Url for request. 
+	 * @param postData Data to be posted
+	 * @return HTTP Connection for response handling
+	 * @throws MalformedURLException
+	 * @throws IOException
+	 */
+	public static HttpURLConnection postRequestWithResponse( String url, byte[] postData ) throws MalformedURLException, IOException
+	{
+		return postRequestWithResponse( url, postData, "application/octet-stream" );
 	}
 	
 	/**


### PR DESCRIPTION
This pull request consists mostly of these three items:
- When trying to load an out of bounds multisets block, do not try to load from dvid (which would include a write on unsuccessful load). Instead, just generate a multiset block that contains for each pixels the background label and the appropriate count only.
- Store block data sets for _almost_ arbitrarily sized types in dvid. If the need for more flexible, i.e. truly arbitrarily sized types, arises, changes can be mad accordingly. _Almost_ as in size in bytes of data type must be
  - an integer divisor of 32 (1,2,4,8,16,32)
  - less than or equal to 32
- Some bug fixes loosely related to above two items
