### PR TITLE
Make AnnotationsHdf5Store reader robust to empty annotations

### DIFF
--- a/src/main/java/bdv/bigcat/annotation/AnnotationsHdf5Store.java
+++ b/src/main/java/bdv/bigcat/annotation/AnnotationsHdf5Store.java
@@ -139,7 +139,7 @@ public class AnnotationsHdf5Store implements AnnotationsStore {
 		try {
 			locations = reader.float32().readMDArray(groupname + "/" + locationsDataset);
 			ids = reader.uint64().readMDArray(groupname + "/" + idsDataset);
-			if (typesDataset != null)
+			if (typesDataset != null && locations.size() > 0 )
 				types = reader.string().readArray(groupname + "/" + typesDataset);
 			else
 				types = null;
@@ -164,6 +164,8 @@ public class AnnotationsHdf5Store implements AnnotationsStore {
 					comments.put(commentTargets.get(i), commentList[i]);
 			}
 		} catch (final HDF5SymbolTableException e) {
+			System.out.println("HDF5 file does not contain comments for " + type);
+		} catch (final NullPointerException e) {
 			System.out.println("HDF5 file does not contain comments for " + type);
 		}
 


### PR DESCRIPTION
Fix issue in which an Exception is thrown if an annotations
dataset is present, but empty.
