### PR TITLE
Specify min and max for raw data

### DIFF
--- a/src/main/java/bdv/bigcat/viewer/atlas/opendialog/BackendDialog.java
+++ b/src/main/java/bdv/bigcat/viewer/atlas/opendialog/BackendDialog.java
@@ -70,6 +70,16 @@ public interface BackendDialog
 		return new SimpleDoubleProperty( Double.NaN );
 	}
 
+	public default DoubleProperty min()
+	{
+		return new SimpleDoubleProperty( Double.NaN );
+	}
+
+	public default DoubleProperty max()
+	{
+		return new SimpleDoubleProperty( Double.NaN );
+	}
+
 //	TODO
 //	public DataSource< ?, ? > getChannels();
 

--- a/src/main/java/bdv/bigcat/viewer/atlas/opendialog/BackendDialogN5.java
+++ b/src/main/java/bdv/bigcat/viewer/atlas/opendialog/BackendDialogN5.java
@@ -40,7 +40,6 @@ import javafx.collections.ObservableList;
 import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.ComboBox;
-import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Priority;
@@ -63,6 +62,10 @@ public class BackendDialogN5 implements BackendDialog
 
 	private static final String OFFSET_KEY = "offset";
 
+	private static final String MIN_KEY = "min";
+
+	private static final String MAX_KEY = "max";
+
 	private final SimpleObjectProperty< String > n5 = new SimpleObjectProperty<>();
 
 	private final SimpleObjectProperty< String > dataset = new SimpleObjectProperty<>();
@@ -80,6 +83,10 @@ public class BackendDialogN5 implements BackendDialog
 	private final SimpleDoubleProperty offY = new SimpleDoubleProperty( Double.NaN );
 
 	private final SimpleDoubleProperty offZ = new SimpleDoubleProperty( Double.NaN );
+
+	private final SimpleDoubleProperty min = new SimpleDoubleProperty( Double.NaN );
+
+	private final SimpleDoubleProperty max = new SimpleDoubleProperty( Double.NaN );
 
 	private final ObservableList< String > datasetChoices = FXCollections.observableArrayList();
 	{
@@ -119,6 +126,9 @@ public class BackendDialogN5 implements BackendDialog
 					offY.set( offset[ 1 ] );
 					offZ.set( offset[ 2 ] );
 
+					min.set( attributes.containsKey( MIN_KEY ) ? attributes.get( MIN_KEY ).getAsDouble() : Double.NaN );
+					max.set( attributes.containsKey( MAX_KEY ) ? attributes.get( MAX_KEY ).getAsDouble() : Double.NaN );
+
 				}
 				catch ( final IOException e )
 				{
@@ -143,17 +153,18 @@ public class BackendDialogN5 implements BackendDialog
 		final TextField n5Field = new TextField( n5.get() );
 		n5Field.setMinWidth( 0 );
 		n5Field.setMaxWidth( Double.POSITIVE_INFINITY );
-		final ComboBox< String > datasetDropDown = new ComboBox<>( datasetChoices );
+		n5Field.setPromptText( "n5 group" );
 		n5Field.textProperty().bindBidirectional( n5 );
+		final ComboBox< String > datasetDropDown = new ComboBox<>( datasetChoices );
+		datasetDropDown.setPromptText( "Choose Dataset..." );
+		datasetDropDown.setEditable( false );
 		datasetDropDown.valueProperty().bindBidirectional( dataset );
 		datasetDropDown.setMinWidth( n5Field.getMinWidth() );
 		datasetDropDown.setPrefWidth( n5Field.getPrefWidth() );
 		datasetDropDown.setMaxWidth( n5Field.getMaxWidth() );
 		final GridPane grid = new GridPane();
-		grid.add( new Label( "n5" ), 0, 0 );
-		grid.add( new Label( "data set" ), 0, 1 );
-		grid.add( n5Field, 1, 0 );
-		grid.add( datasetDropDown, 1, 1 );
+		grid.add( n5Field, 0, 0 );
+		grid.add( datasetDropDown, 0, 1 );
 		GridPane.setHgrow( n5Field, Priority.ALWAYS );
 		GridPane.setHgrow( datasetDropDown, Priority.ALWAYS );
 		final Button button = new Button( "Browse" );
@@ -164,7 +175,7 @@ public class BackendDialogN5 implements BackendDialog
 			final File directory = directoryChooser.showDialog( grid.getScene().getWindow() );
 			Optional.ofNullable( directory ).map( File::getAbsolutePath ).ifPresent( n5::set );
 		} );
-		grid.add( button, 2, 0 );
+		grid.add( button, 1, 0 );
 		return grid;
 	}
 
@@ -331,6 +342,18 @@ public class BackendDialogN5 implements BackendDialog
 	public DoubleProperty offsetZ()
 	{
 		return this.offZ;
+	}
+
+	@Override
+	public DoubleProperty min()
+	{
+		return this.min;
+	}
+
+	@Override
+	public DoubleProperty max()
+	{
+		return this.max;
 	}
 
 }

--- a/src/main/java/bdv/bigcat/viewer/atlas/opendialog/MetaPanel.java
+++ b/src/main/java/bdv/bigcat/viewer/atlas/opendialog/MetaPanel.java
@@ -1,0 +1,248 @@
+package bdv.bigcat.viewer.atlas.opendialog;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.function.UnaryOperator;
+
+import bdv.bigcat.viewer.util.InvokeOnJavaFXApplicationThread;
+import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.collections.ObservableList;
+import javafx.scene.Node;
+import javafx.scene.control.Label;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.control.TextField;
+import javafx.scene.control.TextFormatter;
+import javafx.scene.control.TextFormatter.Change;
+import javafx.scene.control.TitledPane;
+import javafx.scene.layout.ColumnConstraints;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
+
+public class MetaPanel
+{
+
+	private static final double GRID_HGAP = 0;
+
+	private static final double TEXTFIELD_WIDTH = 80;
+
+	private static final String X_STRING = "X";
+
+	private static final String Y_STRING = "Y";
+
+	private static final String Z_STRING = "Z";
+
+	private final TextField resX = new TextField( "" );
+
+	private final TextField resY = new TextField( "" );
+
+	private final TextField resZ = new TextField( "" );
+
+	private final TextField offX = new TextField( "" );
+
+	private final TextField offY = new TextField( "" );
+
+	private final TextField offZ = new TextField( "" );
+
+	private final TextField min = new TextField( "" );
+
+	private final TextField max = new TextField( "" );
+
+	private final VBox content = new VBox();
+
+	private final ScrollPane cc = new ScrollPane( content );
+
+	private final TitledPane pane = new TitledPane( "meta", cc );
+
+	private final VBox rawMeta = new VBox();
+
+	private final VBox labelMeta = new VBox();
+
+	private final HashSet< Node > additionalMeta = new HashSet<>();
+
+	private final SimpleObjectProperty< OpenSourceDialog.TYPE > dataType = new SimpleObjectProperty<>( null );
+
+	public MetaPanel()
+	{
+		cc.setFitToWidth( true );
+
+		final GridPane resolutionAndOffset = new GridPane();
+		resolutionAndOffset.setHgap( GRID_HGAP );
+		final Label resolutionLabel = new Label( "resolution" );
+		final Label offsetLabel = new Label( "offset" );
+		resolutionAndOffset.add( resolutionLabel, 0, 0 );
+		resolutionAndOffset.add( offsetLabel, 0, 1 );
+		resolutionAndOffset.add( resX, 1, 0 );
+		resolutionAndOffset.add( resY, 2, 0 );
+		resolutionAndOffset.add( resZ, 3, 0 );
+		resolutionAndOffset.add( offX, 1, 1 );
+		resolutionAndOffset.add( offY, 2, 1 );
+		resolutionAndOffset.add( offZ, 3, 1 );
+
+		resX.setPrefWidth( TEXTFIELD_WIDTH );
+		resY.setPrefWidth( TEXTFIELD_WIDTH );
+		resZ.setPrefWidth( TEXTFIELD_WIDTH );
+		offX.setPrefWidth( TEXTFIELD_WIDTH );
+		offY.setPrefWidth( TEXTFIELD_WIDTH );
+		offZ.setPrefWidth( TEXTFIELD_WIDTH );
+
+		resX.setPromptText( X_STRING );
+		resY.setPromptText( Y_STRING );
+		resZ.setPromptText( Z_STRING );
+		offX.setPromptText( X_STRING );
+		offY.setPromptText( Y_STRING );
+		offZ.setPromptText( Z_STRING );
+
+		final ColumnConstraints cc = new ColumnConstraints();
+		cc.setHgrow( Priority.ALWAYS );
+		resolutionAndOffset.getColumnConstraints().addAll( cc );
+
+		resX.setTextFormatter( new TextFormatter<>( new DoubleFilter() ) );
+		resY.setTextFormatter( new TextFormatter<>( new DoubleFilter() ) );
+		resZ.setTextFormatter( new TextFormatter<>( new DoubleFilter() ) );
+
+		offX.setTextFormatter( new TextFormatter<>( new DoubleFilter() ) );
+		offY.setTextFormatter( new TextFormatter<>( new DoubleFilter() ) );
+		offZ.setTextFormatter( new TextFormatter<>( new DoubleFilter() ) );
+		content.getChildren().add( resolutionAndOffset );
+
+		this.dataType.addListener( ( obs, oldv, newv ) -> {
+			if ( newv != null )
+				InvokeOnJavaFXApplicationThread.invoke( () -> {
+					final ObservableList< Node > children = this.content.getChildren();
+					children.removeAll( this.additionalMeta );
+					this.additionalMeta.clear();
+					switch ( newv )
+					{
+					case RAW:
+						children.add( this.rawMeta );
+						this.additionalMeta.add( this.rawMeta );
+						break;
+					case LABEL:
+						children.add( this.labelMeta );
+						this.additionalMeta.add( this.labelMeta );
+						break;
+					default:
+						break;
+					}
+				} );
+		} );
+
+		final GridPane rawMinMax = new GridPane();
+		rawMinMax.getColumnConstraints().add( cc );
+		rawMinMax.add( new Label( "Intensity Range" ), 0, 0 );
+		rawMinMax.add( this.min, 1, 0 );
+		rawMinMax.add( this.max, 2, 0 );
+		this.min.setPromptText( "min" );
+		this.max.setPromptText( "max" );
+		this.min.setPrefWidth( TEXTFIELD_WIDTH );
+		this.max.setPrefWidth( TEXTFIELD_WIDTH );
+		this.rawMeta.getChildren().add( rawMinMax );
+
+	}
+
+	public void listenOnResolution( final DoubleProperty resX, final DoubleProperty resY, final DoubleProperty resZ )
+	{
+		resX.addListener( ( obsRes, oldRes, newRes ) -> {
+			if ( Double.isFinite( newRes.doubleValue() ) )
+				this.resX.setText( newRes.toString() );
+		} );
+
+		resY.addListener( ( obsRes, oldRes, newRes ) -> {
+			if ( Double.isFinite( newRes.doubleValue() ) )
+				this.resY.setText( newRes.toString() );
+		} );
+
+		resZ.addListener( ( obsRes, oldRes, newRes ) -> {
+			if ( Double.isFinite( newRes.doubleValue() ) )
+				this.resZ.setText( newRes.toString() );
+		} );
+	}
+
+	public void listenOnOffset( final DoubleProperty offX, final DoubleProperty offY, final DoubleProperty offZ )
+	{
+		offX.addListener( ( obsOff, oldOff, newOff ) -> {
+			if ( Double.isFinite( newOff.doubleValue() ) )
+				this.offX.setText( newOff.toString() );
+		} );
+
+		offY.addListener( ( obsOff, oldOff, newOff ) -> {
+			if ( Double.isFinite( newOff.doubleValue() ) )
+				this.offY.setText( newOff.toString() );
+		} );
+
+		offZ.addListener( ( obsOff, oldOff, newOff ) -> {
+			if ( Double.isFinite( newOff.doubleValue() ) )
+				this.offZ.setText( newOff.toString() );
+		} );
+	}
+
+	public void listenOnMinMax( final DoubleProperty min, final DoubleProperty max )
+	{
+		min.addListener( ( obs, oldv, newv ) -> {
+			if ( Double.isFinite( newv.doubleValue() ) )
+				this.min.setText( Double.toString( newv.doubleValue() ) );
+		} );
+
+		max.addListener( ( obs, oldv, newv ) -> {
+			if ( Double.isFinite( newv.doubleValue() ) )
+				this.max.setText( Double.toString( newv.doubleValue() ) );
+		} );
+	}
+
+	public Node getPane()
+	{
+		return pane;
+	}
+
+	public static class DoubleFilter implements UnaryOperator< Change >
+	{
+
+		@Override
+		public Change apply( final Change t )
+		{
+			final String input = t.getText();
+			return input.matches( "\\d*(\\.\\d*)?" ) ? t : null;
+		}
+	}
+
+	public double[] getResolution()
+	{
+		return Arrays
+				.asList( resX, resY, resZ )
+				.stream()
+				.map( res -> res.getText() )
+				.mapToDouble( text -> text.length() > 0 ? Double.parseDouble( text ) : 1.0 )
+				.toArray();
+	}
+
+	public double[] getOffset()
+	{
+		return Arrays
+				.asList( offX, offY, offZ )
+				.stream()
+				.map( res -> res.getText() )
+				.mapToDouble( text -> text.length() > 0 ? Double.parseDouble( text ) : 0.0 )
+				.toArray();
+	}
+
+	public double min()
+	{
+		final String text = min.getText();
+		return text.length() > 0 ? Double.parseDouble( min.getText() ) : Double.NaN;
+	}
+
+	public double max()
+	{
+		final String text = max.getText();
+		return text.length() > 0 ? Double.parseDouble( max.getText() ) : Double.NaN;
+	}
+
+	public void bindDataTypeTo( final ObjectProperty< OpenSourceDialog.TYPE > dataType )
+	{
+		this.dataType.bind( dataType );
+	}
+
+}

--- a/src/main/java/bdv/bigcat/viewer/atlas/opendialog/OpenSourceDialog.java
+++ b/src/main/java/bdv/bigcat/viewer/atlas/opendialog/OpenSourceDialog.java
@@ -1,8 +1,6 @@
 package bdv.bigcat.viewer.atlas.opendialog;
 
-import java.util.Arrays;
 import java.util.Optional;
-import java.util.function.UnaryOperator;
 
 import bdv.bigcat.viewer.util.InvokeOnJavaFXApplicationThread;
 import javafx.beans.property.SimpleObjectProperty;
@@ -15,11 +13,8 @@ import javafx.scene.control.ComboBox;
 import javafx.scene.control.Dialog;
 import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
-import javafx.scene.control.TextFormatter;
-import javafx.scene.control.TextFormatter.Change;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Priority;
-import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 
@@ -56,24 +51,14 @@ public class OpenSourceDialog extends Dialog< BackendDialog >
 
 	private final SimpleObjectProperty< BackendDialog > currentBackend = new SimpleObjectProperty<>( new BackendDialogInvalid( BACKEND.N5 ) );
 
-	private final SimpleObjectProperty< String > name = new SimpleObjectProperty<>( "source name" );
+	private final SimpleObjectProperty< String > name = new SimpleObjectProperty<>( "" );
 
 	private final ObservableMap< BACKEND, BackendDialog > backendInfoDialogs = FXCollections.observableHashMap();
 	{
 		backendInfoDialogs.put( BACKEND.N5, new BackendDialogN5() );
 	}
 
-	private final TextField resX = new TextField( "1.0" );
-
-	private final TextField resY = new TextField( "1.0" );
-
-	private final TextField resZ = new TextField( "1.0" );
-
-	private final TextField offX = new TextField( "0.0" );
-
-	private final TextField offY = new TextField( "0.0" );
-
-	private final TextField offZ = new TextField( "0.0" );
+	private final MetaPanel metaPanel = new MetaPanel();
 
 	public OpenSourceDialog()
 	{
@@ -97,11 +82,13 @@ public class OpenSourceDialog extends Dialog< BackendDialog >
 
 		this.grid = new GridPane();
 		this.backendDialog = new StackPane();
-		final GridPane resolutionAndOffset = new GridPane();
 		final TextField nameField = new TextField();
 		nameField.textProperty().bindBidirectional( this.name );
-		this.dialogContent = new VBox( 10, nameField, grid, errorInfo, resolutionAndOffset );
+		nameField.setPromptText( "source name (required)" );
+		this.dialogContent = new VBox( 10, nameField, grid, errorInfo, metaPanel.getPane() );
 		this.setResizable( true );
+
+		this.name.addListener( ( obs, oldv, newv ) -> this.getDialogPane().lookupButton( ButtonType.OK ).setDisable( newv == null || newv.length() == 0 ) );
 
 		GridPane.setMargin( this.backendDialog, new Insets( 0, 0, 0, 30 ) );
 		this.grid.add( this.backendDialog, 1, 0 );
@@ -111,6 +98,7 @@ public class OpenSourceDialog extends Dialog< BackendDialog >
 		final VBox choices = new VBox();
 		this.backendChoice = new ComboBox<>( backendChoices );
 		this.typeChoice = new ComboBox<>( typeChoices );
+		this.metaPanel.bindDataTypeTo( this.typeChoice.valueProperty() );
 
 		this.backendChoice.valueProperty().addListener( ( obs, oldv, newv ) -> {
 			InvokeOnJavaFXApplicationThread.invoke( () -> {
@@ -119,53 +107,9 @@ public class OpenSourceDialog extends Dialog< BackendDialog >
 				this.errorMessage.bind( backendDialog.errorMessage() );
 				this.currentBackend.set( backendDialog );
 
-				backendDialog.resolutionX().addListener( ( obsRes, oldRes, newRes ) -> {
-					if ( Double.isFinite( newRes.doubleValue() ) )
-						this.resX.setText( newRes.toString() );
-				} );
-
-				backendDialog.resolutionY().addListener( ( obsRes, oldRes, newRes ) -> {
-					if ( Double.isFinite( newRes.doubleValue() ) )
-						this.resY.setText( newRes.toString() );
-				} );
-
-				backendDialog.resolutionZ().addListener( ( obsRes, oldRes, newRes ) -> {
-					if ( Double.isFinite( newRes.doubleValue() ) )
-						this.resZ.setText( newRes.toString() );
-				} );
-
-				backendDialog.offsetX().addListener( ( obsRes, oldRes, newRes ) -> {
-					if ( Double.isFinite( newRes.doubleValue() ) )
-						this.offX.setText( newRes.toString() );
-				} );
-
-				backendDialog.offsetY().addListener( ( obsRes, oldRes, newRes ) -> {
-					if ( Double.isFinite( newRes.doubleValue() ) )
-						this.offY.setText( newRes.toString() );
-				} );
-
-				backendDialog.offsetZ().addListener( ( obsRes, oldRes, newRes ) -> {
-					if ( Double.isFinite( newRes.doubleValue() ) )
-						this.offZ.setText( newRes.toString() );
-				} );
-
-				if ( Double.isFinite( backendDialog.resolutionX().get() ) )
-					this.resX.setText( Double.toString( backendDialog.resolutionX().get() ) );
-
-				if ( Double.isFinite( backendDialog.resolutionY().get() ) )
-					this.resY.setText( Double.toString( backendDialog.resolutionY().get() ) );
-
-				if ( Double.isFinite( backendDialog.resolutionZ().get() ) )
-					this.resZ.setText( Double.toString( backendDialog.resolutionZ().get() ) );
-
-				if ( Double.isFinite( backendDialog.offsetX().get() ) )
-					this.offX.setText( Double.toString( backendDialog.offsetX().get() ) );
-
-				if ( Double.isFinite( backendDialog.resolutionY().get() ) )
-					this.offY.setText( Double.toString( backendDialog.offsetY().get() ) );
-
-				if ( Double.isFinite( backendDialog.resolutionZ().get() ) )
-					this.offZ.setText( Double.toString( backendDialog.offsetZ().get() ) );
+				this.metaPanel.listenOnResolution( backendDialog.resolutionX(), backendDialog.resolutionY(), backendDialog.resolutionZ() );
+				this.metaPanel.listenOnOffset( backendDialog.offsetX(), backendDialog.offsetY(), backendDialog.offsetZ() );
+				this.metaPanel.listenOnMinMax( backendDialog.min(), backendDialog.max() );
 
 			} );
 		} );
@@ -178,31 +122,6 @@ public class OpenSourceDialog extends Dialog< BackendDialog >
 		this.grid.add( choices, 0, 0 );
 		this.setResultConverter( button -> button.equals( ButtonType.OK ) ? currentBackend.get() : new BackendDialogInvalid( backendChoice.getValue() ) );
 
-		resX.setTextFormatter( new TextFormatter<>( new DoubleFilter() ) );
-		resY.setTextFormatter( new TextFormatter<>( new DoubleFilter() ) );
-		resZ.setTextFormatter( new TextFormatter<>( new DoubleFilter() ) );
-
-		offX.setTextFormatter( new TextFormatter<>( new DoubleFilter() ) );
-		offY.setTextFormatter( new TextFormatter<>( new DoubleFilter() ) );
-		offZ.setTextFormatter( new TextFormatter<>( new DoubleFilter() ) );
-
-		final Label resolutionLabel = new Label();
-		final Label offsetLabel = new Label();
-		resolutionLabel.minWidthProperty().bindBidirectional( offsetLabel.minWidthProperty() );
-		resolutionLabel.maxWidthProperty().bindBidirectional( offsetLabel.maxWidthProperty() );
-		resolutionLabel.prefWidthProperty().bindBidirectional( offsetLabel.prefWidthProperty() );
-		resolutionLabel.setText( "resolution" );
-		offsetLabel.setText( "offset" );
-		offsetLabel.setMinWidth( Region.USE_PREF_SIZE );
-		resolutionAndOffset.add( resolutionLabel, 0, 0 );
-		resolutionAndOffset.add( offsetLabel, 0, 1 );
-		resolutionAndOffset.add( resX, 1, 0 );
-		resolutionAndOffset.add( resY, 2, 0 );
-		resolutionAndOffset.add( resZ, 3, 0 );
-		resolutionAndOffset.add( offX, 1, 1 );
-		resolutionAndOffset.add( offY, 2, 1 );
-		resolutionAndOffset.add( offZ, 3, 1 );
-
 	}
 
 	public TYPE getType()
@@ -210,40 +129,14 @@ public class OpenSourceDialog extends Dialog< BackendDialog >
 		return typeChoice.getValue();
 	}
 
-	public static class DoubleFilter implements UnaryOperator< Change >
-	{
-
-		@Override
-		public Change apply( final Change t )
-		{
-			final String input = t.getText();
-			return input.matches( "\\d*(\\.\\d*)?" ) ? t : null;
-		}
-	}
-
-	public double[] getResolution()
-	{
-		return Arrays
-				.asList( resX, resY, resZ )
-				.stream()
-				.map( res -> res.getText() )
-				.mapToDouble( text -> text.length() > 0 ? Double.parseDouble( text ) : 1.0 )
-				.toArray();
-	}
-
-	public double[] getOffset()
-	{
-		return Arrays
-				.asList( offX, offY, offZ )
-				.stream()
-				.map( res -> res.getText() )
-				.mapToDouble( text -> text.length() > 0 ? Double.parseDouble( text ) : 0.0 )
-				.toArray();
-	}
-
 	public String getName()
 	{
 		return name.get();
+	}
+
+	public MetaPanel getMeta()
+	{
+		return this.metaPanel;
 	}
 
 }


### PR DESCRIPTION
 - Users can specify min and max intensities for raw data to load arbitrary contrast data
 - n5 checks for min/max key in attributes
 - If not specified, defaults to reasonable value (RealType.getMinValue/getMaxValue for IntegerType, (0,1) otherwise)
 - Make own class for meta information