### PR TITLE
Read chunk size from hdf5 file.

### DIFF
--- a/src/main/java/bdv/bigcat/viewer/atlas/opendialog/BackendDialog.java
+++ b/src/main/java/bdv/bigcat/viewer/atlas/opendialog/BackendDialog.java
@@ -81,7 +81,7 @@ public interface BackendDialog
 		return new SimpleDoubleProperty( Double.NaN );
 	}
 
-	public default void typeChanged( TYPE type )
+	public default void typeChanged( final TYPE type )
 	{}
 
 //	TODO


### PR DESCRIPTION
The hdf opener dialog hard codes the chunk size to the cremi cell size. This PR fixes this and reads the chunk size from the h5 file. If the data is not chunked, chunk size/cell size defaults to image dimensions.

This is the same as #31 but with the correct base branch. I was able to change the base branch in #31 but it still listed 725 commits to be merged.