### PR TITLE
Specify minimum JDK version for build as 1.8.0_101

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
 	<description>Collaborative volume annotation and segmentation with BigDataViewer</description>
 	<properties>
 		<scijava.jvm.version>1.8</scijava.jvm.version>
+		<scijava.jvm.build.version>1.8.0_101</scijava.jvm.build.version>
 	</properties>
 
 	<profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 	<description>Collaborative volume annotation and segmentation with BigDataViewer</description>
 	<properties>
 		<scijava.jvm.version>1.8</scijava.jvm.version>
-		<scijava.jvm.build.version>1.8.0_101</scijava.jvm.build.version>
+		<scijava.jvm.build.version>1.8.0-101</scijava.jvm.build.version>
 	</properties>
 
 	<profiles>


### PR DESCRIPTION
This follows discussion in the ImageJ forum [1] and on ImgLib2 issue
192 [2]. I don't *fully* follow the discussion but the summary is:

- to download BigCat's dependencies, Maven requires https connections,
  but these fail with Java < 1.8.0_101, and
- @ctrueden added support for requiring a minimum Java version for
  Maven builds in an upcoming version of scijava-base.

..[1] http://forum.imagej.net/t/https-to-make-imagej-fiji-more-secure/398/11
..[2] https://github.com/imglib/imglib2/issues/192#issuecomment-349372443