### PR TITLE
TranslateZ along current viewer normal, not along world coordinate system axes

### DIFF
--- a/src/main/java/bdv/bigcat/viewer/ortho/OrthoView.java
+++ b/src/main/java/bdv/bigcat/viewer/ortho/OrthoView.java
@@ -13,7 +13,7 @@ import bdv.bigcat.viewer.bdvfx.KeyTracker;
 import bdv.bigcat.viewer.bdvfx.ViewerPanelFX;
 import bdv.bigcat.viewer.panel.ViewerNode;
 import bdv.bigcat.viewer.panel.ViewerNode.ViewerAxis;
-import bdv.bigcat.viewer.panel.ViewerTransformManager;
+import bdv.bigcat.viewer.panel.transform.ViewerTransformManager;
 import bdv.util.volatiles.SharedQueue;
 import bdv.viewer.SourceAndConverter;
 import bdv.viewer.ViewerOptions;
@@ -106,10 +106,10 @@ public class OrthoView extends GridPane
 		this.setHgap( 1.0 );
 
 		this.addEventFilter( MouseEvent.DRAG_DETECTED, event -> {
-			if(this.resizer.isDraggingPanel())
+			if ( this.resizer.isDraggingPanel() )
 				event.consume();
 		} );
-		
+
 		this.addEventHandler( KeyEvent.KEY_TYPED, event -> {
 			if ( event.getCharacter().equals( "f" ) )
 				maximizeActiveOrthoView( event );
@@ -123,8 +123,8 @@ public class OrthoView extends GridPane
 	private void layoutViewers( final SharedQueue cellCache )
 	{
 		addViewer( ViewerAxis.Z, 0, 0, cellCache );
-		addViewer( ViewerAxis.X, 0, 1, cellCache );
-		addViewer( ViewerAxis.Y, 1, 0, cellCache );
+		addViewer( ViewerAxis.Y, 0, 1, cellCache );
+		addViewer( ViewerAxis.X, 1, 0, cellCache );
 	}
 
 	public void setInfoNode( final Node node )
@@ -199,7 +199,6 @@ public class OrthoView extends GridPane
 					is3DNode = true;
 
 		if ( viewerNodes.contains( focusOwner ) || is3DNode )
-		{
 			// event.consume();
 			if ( !this.state.constraintsManager.isFullScreen() )
 			{
@@ -220,7 +219,6 @@ public class OrthoView extends GridPane
 				this.setHgap( 1 );
 				this.setVgap( 1 );
 			}
-		}
 	}
 
 //	public Node globalSourcesInfoNode()

--- a/src/main/java/bdv/bigcat/viewer/panel/ViewerNode.java
+++ b/src/main/java/bdv/bigcat/viewer/panel/ViewerNode.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 
 import bdv.bigcat.viewer.bdvfx.KeyTracker;
 import bdv.bigcat.viewer.bdvfx.ViewerPanelFX;
+import bdv.bigcat.viewer.panel.transform.ViewerTransformManager;
 import bdv.cache.CacheControl;
 import bdv.viewer.DisplayMode;
 import bdv.viewer.Source;
@@ -67,7 +68,7 @@ public class ViewerNode extends Pane implements ListChangeListener< SourceAndCon
 //		this.viewer.showMultibox( false );
 		this.viewerAxis = viewerAxis;
 		this.state = new ViewerState( this.viewer );
-		this.manager = new ViewerTransformManager( this.viewer, state, globalToViewer( viewerAxis ), keyTracker, visibilityMap );
+		this.manager = new ViewerTransformManager( this.viewer, viewerAxis, state, globalToViewer( viewerAxis ), keyTracker, visibilityMap );
 		initializeViewer();
 		addCrosshair();
 //		https://stackoverflow.com/questions/21657034/javafx-keyevent-propagation-order

--- a/src/main/java/bdv/bigcat/viewer/panel/ViewerNode.java
+++ b/src/main/java/bdv/bigcat/viewer/panel/ViewerNode.java
@@ -138,10 +138,10 @@ public class ViewerNode extends Pane implements ListChangeListener< SourceAndCon
 		case Z:
 			break;
 		case Y:
-			tf.rotate( 1, Math.PI / 2 );
+			tf.rotate( 0, -Math.PI / 2 );
 			break;
 		case X:
-			tf.rotate( 0, -Math.PI / 2 );
+			tf.rotate( 1, Math.PI / 2 );
 			break;
 		}
 		return tf;

--- a/src/main/java/bdv/bigcat/viewer/panel/transform/TranslateZ.java
+++ b/src/main/java/bdv/bigcat/viewer/panel/transform/TranslateZ.java
@@ -1,0 +1,74 @@
+package bdv.bigcat.viewer.panel.transform;
+
+import java.util.Arrays;
+import java.util.function.Predicate;
+
+import bdv.bigcat.viewer.panel.ViewerNode.ViewerAxis;
+import bdv.bigcat.viewer.state.GlobalTransformManager;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.value.ObservableDoubleValue;
+import javafx.beans.value.ObservableValue;
+import javafx.scene.input.ScrollEvent;
+import net.imglib2.realtransform.AffineTransform3D;
+
+class TranslateZ
+{
+
+	private final ObservableDoubleValue rotationSpeed;
+
+	ObjectProperty< GlobalTransformManager > manager = new SimpleObjectProperty<>();
+
+	private final AffineTransform3D worldToSharedViewerSpace;
+
+	private final int axis;
+
+	private final double speedFactor;
+
+	private final Predicate< ScrollEvent >[] eventFilter;
+
+	private final Object synchronizeObject;
+
+	public TranslateZ(
+			final ObservableDoubleValue rotationSpeed,
+			final ObservableValue< GlobalTransformManager > manager,
+			final AffineTransform3D worldToSharedViewerSpace,
+			final ViewerAxis axis,
+			final double speedFactor,
+			final Object synchronizeObject,
+			final Predicate< ScrollEvent >... eventFilter )
+	{
+		this.rotationSpeed = rotationSpeed;
+		this.manager.bind( manager );
+		this.worldToSharedViewerSpace = worldToSharedViewerSpace;
+		this.speedFactor = speedFactor;
+		this.eventFilter = eventFilter;
+		this.axis = axis.equals( ViewerAxis.X ) ? 0 : axis.equals( ViewerAxis.Y ) ? 1 : 2;
+		this.synchronizeObject = synchronizeObject;
+	}
+
+	public void scroll( final ScrollEvent event )
+	{
+		final double wheelRotation = event.getDeltaY();
+		if ( Arrays.stream( eventFilter ).filter( filter -> filter.test( event ) ).count() > 0 )
+			synchronized ( synchronizeObject )
+			{
+				final AffineTransform3D affine = worldToSharedViewerSpace.copy();
+				final AffineTransform3D rotationAndScalingOnly = affine.copy();
+				rotationAndScalingOnly.setTranslation( 0, 0, 0 );
+				final double[] delta = new double[ 3 ];
+				System.out.println( "SETTING FOR AXIS " + axis );
+				delta[ axis ] = 1.0;
+				rotationAndScalingOnly.applyInverse( delta, delta );
+				final double norm = delta[ 0 ] * delta[ 0 ] + delta[ 1 ] * delta[ 1 ] + delta[ 2 ] * delta[ 2 ];
+				final double factor = rotationSpeed.get() * speedFactor * -wheelRotation / Math.sqrt( norm );
+				for ( int d = 0; d < delta.length; ++d )
+					delta[ d ] *= factor;
+				final AffineTransform3D shift = new AffineTransform3D();
+				shift.setTranslation( delta );
+				manager.get().setTransform( affine.concatenate( shift ) );
+				// TODO should we translate on world coordinate level (as we do
+				// now) or after transformations are applied?
+			}
+	}
+}

--- a/src/main/java/bdv/bigcat/viewer/state/GlobalTransformManager.java
+++ b/src/main/java/bdv/bigcat/viewer/state/GlobalTransformManager.java
@@ -41,7 +41,7 @@ public class GlobalTransformManager
 	public void addListener( final TransformListener< AffineTransform3D > listener )
 	{
 		this.listeners.add( listener );
-		listener.transformChanged( this.affine );
+		listener.transformChanged( this.affine.copy() );
 	}
 
 	public void removeListener( final TransformListener< AffineTransform3D > listener )
@@ -64,7 +64,7 @@ public class GlobalTransformManager
 	private synchronized void notifyListeners()
 	{
 		for ( final TransformListener< AffineTransform3D > l : listeners )
-			l.transformChanged( this.affine );
+			l.transformChanged( this.affine.copy() );
 	}
 
 }


### PR DESCRIPTION
Currently, the translation is applied on the world level (before any other transformation is applied). This means that all translations have the same delta. If this is not the desired behavior (i.e. delta should adapt to scale), I will adapt the PR.