### PR TITLE
Further reduce responsibility of actual viewer nodes

### DIFF
--- a/src/main/java/bdv/bigcat/viewer/atlas/AtlasValueDisplayListener.java
+++ b/src/main/java/bdv/bigcat/viewer/atlas/AtlasValueDisplayListener.java
@@ -10,6 +10,7 @@ import bdv.bigcat.viewer.atlas.data.DataSource;
 import bdv.bigcat.viewer.bdvfx.ViewerPanelFX;
 import bdv.viewer.Source;
 import javafx.application.Platform;
+import javafx.beans.value.ObservableIntegerValue;
 import javafx.beans.value.ObservableValue;
 import javafx.scene.control.Label;
 import javafx.scene.input.MouseEvent;
@@ -26,11 +27,14 @@ public class AtlasValueDisplayListener
 
 	private final ObservableValue< Source< ? > > currentSource;
 
-	public AtlasValueDisplayListener( final Label statusBar, final ObservableValue< Source< ? > > currentSource )
+	private final ObservableIntegerValue currentSourceIndexInVisibleSources;
+
+	public AtlasValueDisplayListener( final Label statusBar, final ObservableValue< Source< ? > > currentSource, final ObservableIntegerValue currentSourceIndexInVisibleSources )
 	{
 		super();
 		this.statusBar = statusBar;
 		this.currentSource = currentSource;
+		this.currentSourceIndexInVisibleSources = currentSourceIndexInVisibleSources;
 	}
 
 	public < D, T > void addSource( final DataSource< D, T > dataSource, final Optional< Function< D, String > > valueToString )
@@ -46,7 +50,7 @@ public class AtlasValueDisplayListener
 	{
 		return t -> {
 			if ( !this.listeners.containsKey( t ) )
-				this.listeners.put( t, new ValueDisplayListener( handlerMap, t, currentSource ) );
+				this.listeners.put( t, new ValueDisplayListener( handlerMap, t, currentSource, currentSourceIndexInVisibleSources ) );
 			t.getDisplay().addEventHandler( MouseEvent.MOUSE_MOVED, this.listeners.get( t ) );
 			t.addTransformListener( this.listeners.get( t ) );
 		};

--- a/src/main/java/bdv/bigcat/viewer/atlas/mode/RenderNeuron.java
+++ b/src/main/java/bdv/bigcat/viewer/atlas/mode/RenderNeuron.java
@@ -78,11 +78,10 @@ public class RenderNeuron
 		{
 			final ViewerState state = viewer.getState();
 			final Source< ? > source = sourceInfo.currentSourceProperty().get();
-			if ( source != null )
-			{
-				final int sourceIndex = sourceInfo.currentSourceIndexProperty().get();
+			if ( source != null && sourceInfo.getState( source ).visibleProperty().get() )
 				if ( source instanceof DataSource< ?, ? > )
 				{
+					final int sourceIndex = sourceInfo.trackVisibleSources().indexOf( source );
 					final DataSource< ?, ? > dataSource = sourceInfo.getState( source ).dataSourceProperty().get();
 					final Optional< Function< ?, Converter< ?, BoolType > > > toBoolConverter = sourceInfo.toBoolConverter( source );
 					final Optional< ToIdConverter > idConverter = sourceInfo.toIdConverter( source );
@@ -178,7 +177,6 @@ public class RenderNeuron
 							LOG.warn( "Selected irregular label: {}. Will not render.", selectedId );
 					}
 				}
-			}
 		}
 	}
 

--- a/src/main/java/bdv/bigcat/viewer/atlas/source/AtlasSourceState.java
+++ b/src/main/java/bdv/bigcat/viewer/atlas/source/AtlasSourceState.java
@@ -9,6 +9,7 @@ import bdv.bigcat.viewer.atlas.data.DataSource;
 import bdv.bigcat.viewer.atlas.mode.Mode;
 import bdv.bigcat.viewer.state.FragmentSegmentAssignmentState;
 import bdv.bigcat.viewer.state.SelectedIds;
+import bdv.viewer.SourceAndConverter;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ObjectProperty;
@@ -55,6 +56,11 @@ public abstract class AtlasSourceState< T, D >
 		return converter.get();
 	}
 
+	public SourceAndConverter< T > getSourceAndConverter()
+	{
+		return new SourceAndConverter<>( dataSource.get(), converter.get() );
+	}
+
 	public ReadOnlyObjectProperty< Converter< T, ARGBType > > converterProperty()
 	{
 		return this.converter;
@@ -88,10 +94,11 @@ public abstract class AtlasSourceState< T, D >
 	public static class LabelSourceState< T, D > extends AtlasSourceState< T, D >
 	{
 
-		public LabelSourceState( final DataSource< D, T > dataSource )
+		public LabelSourceState( final DataSource< D, T > dataSource, final Converter< T, ARGBType > converter )
 		{
 			super.dataSource.set( dataSource );
 			typeProperty().set( TYPE.RAW );
+			setConverter( converter );
 		}
 
 		private final ObjectProperty< FragmentSegmentAssignmentState< ? > > assignment = new SimpleObjectProperty<>();

--- a/src/main/java/bdv/bigcat/viewer/bdvfx/ViewerPanelFX.java
+++ b/src/main/java/bdv/bigcat/viewer/bdvfx/ViewerPanelFX.java
@@ -325,7 +325,7 @@ public class ViewerPanelFX
 		requestRepaint();
 	}
 
-	public void addSources( final Collection< SourceAndConverter< ? > > sourceAndConverter )
+	public void addSources( final Collection< ? extends SourceAndConverter< ? > > sourceAndConverter )
 	{
 		synchronized ( visibilityAndGrouping )
 		{
@@ -360,6 +360,15 @@ public class ViewerPanelFX
 		synchronized ( visibilityAndGrouping )
 		{
 			removeSources( getState().getSources().stream().map( SourceAndConverter::getSpimSource ).collect( Collectors.toList() ) );
+		}
+	}
+
+	public void setAllSources( final Collection< ? extends SourceAndConverter< ? > > sources )
+	{
+		synchronized ( visibilityAndGrouping )
+		{
+			getState().getSources().stream().map( SourceAndConverter::getSpimSource ).forEach( state::removeSource );
+			addSources( sources );
 		}
 	}
 

--- a/src/main/java/bdv/bigcat/viewer/ortho/OrthoView.java
+++ b/src/main/java/bdv/bigcat/viewer/ortho/OrthoView.java
@@ -66,12 +66,12 @@ public class OrthoView extends GridPane
 
 	public OrthoView( final SharedQueue cellCache, final KeyTracker keyTracker )
 	{
-		this( new OrthoViewState( FXCollections.observableHashMap() ), cellCache, keyTracker );
+		this( new OrthoViewState(), cellCache, keyTracker );
 	}
 
 	public OrthoView( final ViewerOptions viewerOptions, final SharedQueue cellCache, final KeyTracker keyTracker )
 	{
-		this( new OrthoViewState( viewerOptions, FXCollections.observableHashMap() ), cellCache, keyTracker );
+		this( new OrthoViewState( viewerOptions ), cellCache, keyTracker );
 	}
 
 	public OrthoView( final OrthoViewState state, final SharedQueue cellCache, final KeyTracker keyTracker )
@@ -170,11 +170,11 @@ public class OrthoView extends GridPane
 
 	private synchronized void addViewer( final ViewerAxis axis, final int rowIndex, final int colIndex, final SharedQueue cellCache )
 	{
-		final ViewerNode viewerNode = new ViewerNode( cellCache, axis, this.state.viewerOptions, keyTracker, this.state.visibility );
+		final ViewerNode viewerNode = new ViewerNode( cellCache, axis, this.state.viewerOptions, keyTracker );
 //		final ViewerNode viewerNode = new ViewerNode( new CacheControl.Dummy(), axis, this.state.viewerOptions, activeKeys );
 		this.viewerNodes.add( viewerNode );
 		this.managers.put( viewerNode, viewerNode.manager() );
-		viewerNode.getViewerState().setSources( state.sacs, state.visibility, state.currentSource, state.interpolation );
+		viewerNode.getViewerState().setSources( state.sacs, state.interpolation );
 		viewerNode.getViewerState().setGlobalTransform( this.state.globalTransform );
 		viewerActors.forEach( actor -> actor.onAdd().accept( viewerNode.getViewer() ) );
 		addViewerNodesHandler( viewerNode, FOCUS_KEEPERS );

--- a/src/main/java/bdv/bigcat/viewer/ortho/OrthoViewState.java
+++ b/src/main/java/bdv/bigcat/viewer/ortho/OrthoViewState.java
@@ -1,8 +1,6 @@
 package bdv.bigcat.viewer.ortho;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.stream.Collectors;
 
 import bdv.bigcat.viewer.state.GlobalTransformManager;
@@ -10,18 +8,12 @@ import bdv.viewer.Interpolation;
 import bdv.viewer.Source;
 import bdv.viewer.SourceAndConverter;
 import bdv.viewer.ViewerOptions;
-import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleIntegerProperty;
 import javafx.beans.property.SimpleObjectProperty;
-import javafx.beans.value.ChangeListener;
 import javafx.collections.FXCollections;
-import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
-import javafx.collections.ObservableMap;
-import net.imglib2.converter.Converter;
-import net.imglib2.type.numeric.ARGBType;
 
 public class OrthoViewState
 {
@@ -32,61 +24,32 @@ public class OrthoViewState
 
 	protected final ViewerOptions viewerOptions;
 
-	protected final ArrayList< Converter< ?, ARGBType > > converters;
-
 	protected final ObservableList< SourceAndConverter< ? > > sacs = FXCollections.observableArrayList();
 
 	protected final SimpleObjectProperty< Interpolation > interpolation = new SimpleObjectProperty<>( Interpolation.NEARESTNEIGHBOR );
 
 	protected final SimpleObjectProperty< Source< ? > > currentSource = new SimpleObjectProperty<>( null );
 
-	protected final ObservableMap< Source< ? >, BooleanProperty > visibility;
-
 	private final IntegerProperty time = new SimpleIntegerProperty();
 
-	public OrthoViewState( final ObservableMap< Source< ? >, BooleanProperty > visibility )
+	public OrthoViewState()
 	{
-		this( ViewerOptions.options(), visibility );
+		this( ViewerOptions.options() );
 	}
 
-	public OrthoViewState( final ViewerOptions viewerOptions, final ObservableMap< Source< ? >, BooleanProperty > visibility )
+	public OrthoViewState( final ViewerOptions viewerOptions )
 	{
-		this( viewerOptions, new GlobalTransformManager(), new GridConstraintsManager(), new ArrayList<>(), visibility );
+		this( viewerOptions, new GlobalTransformManager(), new GridConstraintsManager() );
 	}
 
 	public OrthoViewState(
 			final ViewerOptions viewerOptions,
 			final GlobalTransformManager globalTransform,
-			final GridConstraintsManager constraintsManager,
-			final List< Converter< ?, ARGBType > > converters,
-			final ObservableMap< Source< ? >, BooleanProperty > visibility )
+			final GridConstraintsManager constraintsManager )
 	{
 		this.viewerOptions = viewerOptions;
 		this.globalTransform = globalTransform;
 		this.constraintsManager = constraintsManager;
-		this.converters = new ArrayList<>();
-		this.converters.addAll( converters );
-		this.visibility = visibility;
-	}
-
-	protected void trackConverters( final ObservableList< SourceAndConverter< ? > > list )
-	{
-		list.addListener( new UpdateConverters() );
-	}
-
-	private class UpdateConverters implements ListChangeListener< SourceAndConverter< ? > >
-	{
-
-		@Override
-		public void onChanged( final Change< ? extends SourceAndConverter< ? > > c )
-		{
-			while ( c.next() )
-			{
-				converters.clear();
-				c.getList().stream().map( SourceAndConverter::getConverter ).forEach( converters::add );
-			}
-		}
-
 	}
 
 	public synchronized void addSource( final SourceAndConverter< ? > source )
@@ -94,19 +57,9 @@ public class OrthoViewState
 		this.sacs.add( source );
 	}
 
-	public synchronized void addSources( final Collection< SourceAndConverter< ? > > sources )
+	public synchronized void addSources( final Collection< ? extends SourceAndConverter< ? > > sources )
 	{
 		this.sacs.addAll( sources );
-	}
-
-	public synchronized void setVisible( final Source< ? > source, final boolean isVisible )
-	{
-		this.visibility.get( source ).set( isVisible );
-	}
-
-	public void addVisibilityListener( final Source< ? > source, final ChangeListener< Boolean > listener )
-	{
-		this.visibility.get( source ).addListener( listener );
 	}
 
 	public synchronized void removeSource( final Source< ? > source )
@@ -119,35 +72,9 @@ public class OrthoViewState
 		sacs.clear();
 	}
 
-	public synchronized List< SourceAndConverter< ? > > getSourcesCopy()
+	public synchronized void setSources( final Collection< ? extends SourceAndConverter< ? > > sources )
 	{
-		return new ArrayList<>( sacs );
-	}
-
-	public synchronized ObservableList< SourceAndConverter< ? > > getSourcesSynchronizedCopy()
-	{
-		final ObservableList< SourceAndConverter< ? > > list = FXCollections.observableArrayList();
-		sacs.addListener( ( ListChangeListener< SourceAndConverter< ? > > ) change -> {
-			while ( change.next() )
-				list.setAll( change.getList() );
-		} );
-		return list;
-	}
-
-	public void toggleInterpolation()
-	{
-		switch ( this.interpolation.get() )
-		{
-		case NEARESTNEIGHBOR:
-			this.interpolation.set( Interpolation.NLINEAR );
-			break;
-		case NLINEAR:
-			this.interpolation.set( Interpolation.NEARESTNEIGHBOR );
-			break;
-		default:
-			this.interpolation.set( Interpolation.NEARESTNEIGHBOR );
-			break;
-		}
+		sacs.setAll( sources );
 	}
 
 	public ObjectProperty< Source< ? > > currentSourceProperty()

--- a/src/main/java/bdv/bigcat/viewer/panel/ViewerState.java
+++ b/src/main/java/bdv/bigcat/viewer/panel/ViewerState.java
@@ -1,17 +1,11 @@
 package bdv.bigcat.viewer.panel;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Optional;
 
 import bdv.bigcat.viewer.bdvfx.ViewerPanelFX;
 import bdv.bigcat.viewer.state.GlobalTransformManager;
 import bdv.viewer.Interpolation;
-import bdv.viewer.Source;
 import bdv.viewer.SourceAndConverter;
-import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.Property;
 import javafx.beans.property.SimpleObjectProperty;
@@ -19,9 +13,7 @@ import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
-import javafx.collections.MapChangeListener;
 import javafx.collections.ObservableList;
-import javafx.collections.ObservableMap;
 
 public class ViewerState
 {
@@ -29,15 +21,11 @@ public class ViewerState
 
 	private final SourcesListener sacs = new SourcesListener();
 
-	private final VisibilityListener visibility = new VisibilityListener();
-
-	private final CurrentSourceListener currentSource = new CurrentSourceListener();
-
+	// TODO extract interpolation handling into SourceInfo
 	private final InterpolationListener interpolation = new InterpolationListener();
 
+	@SuppressWarnings( "unchecked" )
 	private final SimpleObjectProperty< GlobalTransformManager > globalTransform = new SimpleObjectProperty<>( new GlobalTransformManager() );
-
-	private final HashMap< Source< ? >, ChangeListener< Boolean > > visibilityListeners = new HashMap<>();
 
 	public ViewerState( final ViewerPanelFX viewer )
 	{
@@ -68,20 +56,14 @@ public class ViewerState
 
 	public synchronized void setSources( final ViewerState state )
 	{
-		setSources( state.sacs.observable, state.visibility.observable, state.currentSource.observable, state.interpolation.observable );
+		setSources( state.sacs.observable, state.interpolation.observable );
 	}
 
 	public synchronized void setSources(
 			final ObservableList< SourceAndConverter< ? > > sacs,
-			final ObservableMap< Source< ? >, BooleanProperty > isVisible,
-			final ObjectProperty< Source< ? > > currentSource,
 			final ObjectProperty< Interpolation > interpolation )
 	{
 		this.sacs.replaceObservable( sacs );
-		this.sacs.observable.stream().map( SourceAndConverter::getSpimSource ).forEach( s -> Optional.ofNullable( visibility.observable.get( s ) ).ifPresent( v -> v.removeListener( visibilityListeners.get( s ) ) ) );
-		this.visibilityListeners.clear();
-		this.visibility.replaceObservable( isVisible );
-		this.currentSource.replaceObservable( currentSource );
 		this.interpolation.replaceObservable( interpolation );
 	}
 
@@ -101,53 +83,6 @@ public class ViewerState
 			this.observable.removeListener( this );
 			this.observable = observable;
 			this.observable.addListener( this );
-		}
-
-	}
-
-	public class VisibilityListener implements MapChangeListener< Source< ? >, BooleanProperty >
-	{
-
-		private ObservableMap< Source< ? >, BooleanProperty > observable = FXCollections.observableHashMap();
-
-		public void replaceObservable( final ObservableMap< Source< ? >, BooleanProperty > observable )
-		{
-			this.observable.removeListener( this );
-			this.observable = observable;
-			this.observable.addListener( this );
-			this.observable.forEach( ( k, v ) -> {
-				if ( !visibilityListeners.containsKey( k ) )
-					visibilityListeners.put( k, ( obs, oldv, newv ) -> viewer.getVisibilityAndGrouping().setSourceActive( k, newv.booleanValue() ) );
-				v.addListener( visibilityListeners.get( k ) );
-			} );
-		}
-
-		@Override
-		public void onChanged( final Change< ? extends Source< ? >, ? extends BooleanProperty > change )
-		{
-			if ( change.wasRemoved() )
-				change.getValueRemoved().removeListener( visibilityListeners.remove( change.getKey() ) );
-			if ( change.wasAdded() )
-			{
-				if ( !visibilityListeners.containsKey( change.getKey() ) )
-					visibilityListeners.put( change.getKey(), ( obs, oldv, newv ) -> viewer.getVisibilityAndGrouping().setSourceActive( change.getKey(), newv.booleanValue() ) );
-				change.getValueAdded().addListener( visibilityListeners.get( change.getKey() ) );
-			}
-		}
-	}
-
-	public class CurrentSourceListener extends ObservableRegisteringChangeListener< Source< ? > >
-	{
-
-		public CurrentSourceListener()
-		{
-			super( new SimpleObjectProperty<>( null ) );
-		}
-
-		@Override
-		public void changed( final ObservableValue< ? extends Source< ? > > observable, final Source< ? > oldValue, final Source< ? > newValue )
-		{
-			viewer.getVisibilityAndGrouping().setCurrentSource( newValue );
 		}
 
 	}
@@ -184,53 +119,15 @@ public class ViewerState
 		@Override
 		public void onChanged( final Change< ? extends SourceAndConverter< ? > > c )
 		{
-			replaceViewerSources( ( List< SourceAndConverter< ? > > ) c.getList() );
+
+			replaceViewerSources( c.getList() );
 		}
 
-		private void replaceViewerSources( final Collection< SourceAndConverter< ? > > sources )
+		private void replaceViewerSources( final Collection< ? extends SourceAndConverter< ? > > sources )
 		{
-			viewer.removeAllSources();
-			viewer.addSources( sources );
+			viewer.setAllSources( sources );
 		}
 
-	}
-
-	public void setVisibility( final Source< ? > source, final boolean isVisible )
-	{
-		this.visibility.observable.get( source ).set( isVisible );
-	}
-
-	public synchronized void setCurrentSource( final Source< ? > source )
-	{
-		this.currentSource.observable.set( source );
-	}
-
-	public synchronized void addSource( final SourceAndConverter< ? > sac )
-	{
-		this.sacs.observable.add( sac );
-	}
-
-	public synchronized void addSources( final Collection< SourceAndConverter< ? > > sacs )
-	{
-		this.sacs.observable.addAll( sacs );
-	}
-
-	public synchronized void removeSource( final Source< ? > source )
-	{
-		this.sacs.observable.remove( source );
-	}
-
-	public synchronized void removeAllSources()
-	{
-		this.sacs.observable.clear();
-	}
-
-	public List< SourceAndConverter< ? > > getSourcesCopy()
-	{
-		synchronized ( this.sacs )
-		{
-			return new ArrayList<>( this.sacs.observable );
-		}
 	}
 
 	public synchronized void toggleInterpolation()

--- a/src/main/java/bdv/bigcat/viewer/panel/transform/ViewerTransformManager.java
+++ b/src/main/java/bdv/bigcat/viewer/panel/transform/ViewerTransformManager.java
@@ -16,13 +16,10 @@ import bdv.bigcat.viewer.bdvfx.ViewerPanelFX;
 import bdv.bigcat.viewer.panel.ViewerNode.ViewerAxis;
 import bdv.bigcat.viewer.panel.ViewerState;
 import bdv.bigcat.viewer.state.GlobalTransformManager;
-import bdv.viewer.Source;
-import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.Property;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.SimpleObjectProperty;
-import javafx.collections.ObservableMap;
 import javafx.event.EventHandler;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
@@ -72,8 +69,6 @@ public class ViewerTransformManager implements TransformListener< AffineTransfor
 
 	private int centerX = 0, centerY = 0;
 
-	private final ObservableMap< Source< ? >, BooleanProperty > visibilityMap;
-
 	public void rotationSpeed( final double speed )
 	{
 		this.rotationSpeed.set( speed );
@@ -89,8 +84,7 @@ public class ViewerTransformManager implements TransformListener< AffineTransfor
 			final ViewerAxis axis,
 			final ViewerState state,
 			final AffineTransform3D globalToViewer,
-			final KeyTracker keyTracker,
-			final ObservableMap< Source< ? >, BooleanProperty > visibilityMap )
+			final KeyTracker keyTracker )
 	{
 		super();
 		this.viewer = viewer;
@@ -101,7 +95,6 @@ public class ViewerTransformManager implements TransformListener< AffineTransfor
 		this.canvasW = 1;
 		this.centerX = this.canvasW / 2;
 		this.centerY = this.canvasH / 2;
-		this.visibilityMap = visibilityMap;
 
 		setTransformListener( viewer );
 		manager.addListener( ( obs, oldv, newv ) -> {


### PR DESCRIPTION
Viewer nodes should only render sources. With this commit, this is what they do now. Currently, we do not have a per source interpolation, so `ViewerState` still holds a interpolation property (to be removed in the future).