### PR TITLE
Add switch to choose between colors from segment id or fragment id

### DIFF
--- a/src/main/java/bdv/bigcat/viewer/atlas/Atlas.java
+++ b/src/main/java/bdv/bigcat/viewer/atlas/Atlas.java
@@ -408,7 +408,6 @@ public class Atlas
 			final IdService idService )
 	{
 		final CurrentModeConverter< VolatileLabelMultisetType, HighlightingStreamConverterLabelMultisetType > converter = new CurrentModeConverter<>();
-		final Converter< VolatileLabelMultisetType, ARGBType > condafsdf = converter;
 		final HashMap< Mode, SelectedIds > selIdsMap = new HashMap<>();
 		final HashMap< Mode, ARGBStream > streamsMap = new HashMap<>();
 		for ( final Mode mode : this.settings.availableModes() )

--- a/src/main/java/bdv/bigcat/viewer/atlas/CurrentModeConverter.java
+++ b/src/main/java/bdv/bigcat/viewer/atlas/CurrentModeConverter.java
@@ -2,17 +2,20 @@ package bdv.bigcat.viewer.atlas;
 
 import java.util.Optional;
 
+import bdv.bigcat.viewer.stream.ColorFromSegmentId;
 import bdv.bigcat.viewer.stream.SeedProperty;
 import bdv.bigcat.viewer.stream.WithAlpha;
 import javafx.beans.binding.Bindings;
+import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.LongProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.SimpleLongProperty;
 import net.imglib2.converter.Converter;
 import net.imglib2.type.numeric.ARGBType;
 
-public class CurrentModeConverter< T, C extends Converter< T, ARGBType > & SeedProperty & WithAlpha > implements Converter< T, ARGBType >, SeedProperty
+public class CurrentModeConverter< T, C extends Converter< T, ARGBType > & SeedProperty & WithAlpha & ColorFromSegmentId > implements Converter< T, ARGBType >, SeedProperty
 {
 
 	private C streamConverter;
@@ -24,6 +27,8 @@ public class CurrentModeConverter< T, C extends Converter< T, ARGBType > & SeedP
 	private final DoubleProperty activeFragmentAlpha = new SimpleDoubleProperty( 0xd0 * 1.0 / 0xff );
 
 	private final DoubleProperty activeSegmentAlpha = new SimpleDoubleProperty( 0x80 * 1.0 / 0xff );
+
+	private final BooleanProperty colorFromSegmentId = new SimpleBooleanProperty( true );
 
 	public CurrentModeConverter()
 	{
@@ -68,6 +73,11 @@ public class CurrentModeConverter< T, C extends Converter< T, ARGBType > & SeedP
 		return this.activeSegmentAlpha;
 	}
 
+	public BooleanProperty colorFromSegmentIdProperty()
+	{
+		return this.colorFromSegmentId;
+	}
+
 	private static int toIntegerBased( final double opacity )
 	{
 		return ( int ) Math.round( 255 * opacity );
@@ -78,6 +88,7 @@ public class CurrentModeConverter< T, C extends Converter< T, ARGBType > & SeedP
 		conv.alphaProperty().unbind();
 		conv.activeFragmentAlphaProperty().unbind();
 		conv.activeSegmentAlphaProperty().unbind();
+		conv.colorFromSegmentIdProperty().unbind();
 	}
 
 	private void bindConverter( final C conv )
@@ -85,6 +96,7 @@ public class CurrentModeConverter< T, C extends Converter< T, ARGBType > & SeedP
 		conv.alphaProperty().bind( Bindings.createIntegerBinding( () -> toIntegerBased( alpha.get() ), alpha ) );
 		conv.activeFragmentAlphaProperty().bind( Bindings.createIntegerBinding( () -> toIntegerBased( activeFragmentAlpha.get() ), activeFragmentAlpha ) );
 		conv.activeSegmentAlphaProperty().bind( Bindings.createIntegerBinding( () -> toIntegerBased( activeSegmentAlpha.get() ), activeSegmentAlpha ) );
+		conv.colorFromSegmentIdProperty().bind( colorFromSegmentId );
 	}
 
 }

--- a/src/main/java/bdv/bigcat/viewer/atlas/source/SourceTabs.java
+++ b/src/main/java/bdv/bigcat/viewer/atlas/source/SourceTabs.java
@@ -332,6 +332,7 @@ public class SourceTabs
 		else if ( converter instanceof CurrentModeConverter< ?, ? > )
 		{
 			final CurrentModeConverter< ?, ? > conv = ( CurrentModeConverter< ?, ? > ) converter;
+			final VBox contents = new VBox();
 			final GridPane gp = new GridPane();
 			final ColumnConstraints secondColumnConstraints = new ColumnConstraints();
 			secondColumnConstraints.setMaxWidth( Double.MAX_VALUE );
@@ -339,6 +340,9 @@ public class SourceTabs
 			gp.getColumnConstraints().addAll( secondColumnConstraints );
 
 			final int textFieldWidth = 60;
+			int row = 0;
+
+			contents.getChildren().add( gp );
 
 			{
 				final Slider alphaSlider = new Slider( 0, 1, conv.alphaProperty().get() );
@@ -349,8 +353,9 @@ public class SourceTabs
 				alphaField.textProperty().bindBidirectional( alphaSlider.valueProperty(), new NumberStringConverter() );
 				alphaField.setMinWidth( textFieldWidth );
 				alphaField.setMaxWidth( textFieldWidth );
-				gp.add( alphaSlider, 0, 0 );
-				gp.add( alphaField, 1, 0 );
+				gp.add( alphaSlider, 0, row );
+				gp.add( alphaField, 1, row );
+				++row;
 			}
 
 			{
@@ -362,8 +367,9 @@ public class SourceTabs
 				selectedFragmentAlphaField.textProperty().bindBidirectional( selectedFragmentAlphaSlider.valueProperty(), new NumberStringConverter() );
 				selectedFragmentAlphaField.setMinWidth( textFieldWidth );
 				selectedFragmentAlphaField.setMaxWidth( textFieldWidth );
-				gp.add( selectedFragmentAlphaSlider, 0, 1 );
-				gp.add( selectedFragmentAlphaField, 1, 1 );
+				gp.add( selectedFragmentAlphaSlider, 0, row );
+				gp.add( selectedFragmentAlphaField, 1, row );
+				++row;
 			}
 
 			{
@@ -375,11 +381,22 @@ public class SourceTabs
 				selectedSegmentAlphaField.textProperty().bindBidirectional( selectedSegmentAlphaSlider.valueProperty(), new NumberStringConverter() );
 				selectedSegmentAlphaField.setMinWidth( textFieldWidth );
 				selectedSegmentAlphaField.setMaxWidth( textFieldWidth );
-				gp.add( selectedSegmentAlphaSlider, 0, 2 );
-				gp.add( selectedSegmentAlphaField, 1, 2 );
+				gp.add( selectedSegmentAlphaSlider, 0, row );
+				gp.add( selectedSegmentAlphaField, 1, row );
+				++row;
 			}
 
-			tp.setContent( gp );
+			{
+				final CheckBox colorFromSegmentId = new CheckBox( "Color From segment Id." );
+				colorFromSegmentId.setTooltip( new Tooltip( "Generate fragment color from segment id (on) or fragment id (off)" ) );
+				colorFromSegmentId.selectedProperty().bindBidirectional( conv.colorFromSegmentIdProperty() );
+				contents.getChildren().add( colorFromSegmentId );
+//				gp.add( colorFromSegmentId, 0, row );
+//				gp.add( new Label( "Color From segment Id." ), 1, row );
+//				++row;
+			}
+
+			tp.setContent( contents );
 		}
 
 		return tp;

--- a/src/main/java/bdv/bigcat/viewer/stream/AbstractHighlightingARGBStream.java
+++ b/src/main/java/bdv/bigcat/viewer/stream/AbstractHighlightingARGBStream.java
@@ -23,6 +23,8 @@ import bdv.bigcat.viewer.state.SelectedIds;
 import bdv.labels.labelset.Label;
 import gnu.trove.impl.Constants;
 import gnu.trove.map.hash.TLongIntHashMap;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 
 /**
  * Generates and caches a stream of colors.
@@ -51,10 +53,13 @@ abstract public class AbstractHighlightingARGBStream extends AbstractState< Abst
 
 	protected final FragmentSegmentAssignment assignment;
 
+	private final BooleanProperty colorFromSegmentId = new SimpleBooleanProperty();
+
 	public AbstractHighlightingARGBStream( final SelectedIds highlights, final FragmentSegmentAssignment assignment )
 	{
 		this.highlights = highlights;
 		this.assignment = assignment;
+		this.colorFromSegmentId.addListener( ( obs, oldv, newv ) -> stateChanged() );
 	}
 
 	protected TLongIntHashMap argbCache = new TLongIntHashMap(
@@ -102,18 +107,18 @@ abstract public class AbstractHighlightingARGBStream extends AbstractState< Abst
 
 	protected double getDouble( final long id )
 	{
-		return getDoubleImpl( id );
+		return getDoubleImpl( id, colorFromSegmentId.get() );
 	}
 
-	protected abstract double getDoubleImpl( final long id );
+	protected abstract double getDoubleImpl( final long id, boolean colorFromSegmentId );
 
 	@Override
 	public int argb( final long id )
 	{
-		return argbImpl( id );
+		return argbImpl( id, colorFromSegmentId.get() );
 	}
 
-	protected abstract int argbImpl( long id );
+	protected abstract int argbImpl( long id, boolean colorFromSegmentId );
 
 	/**
 	 * Change the seed.
@@ -210,5 +215,20 @@ abstract public class AbstractHighlightingARGBStream extends AbstractState< Abst
 	{
 		argbCache.clear();
 		stateChanged();
+	}
+
+	public void setColorFromSegmentId( final boolean fromSegmentId )
+	{
+		this.colorFromSegmentId.set( fromSegmentId );
+	}
+
+	public boolean getColorFromSegmentId()
+	{
+		return this.colorFromSegmentId.get();
+	}
+
+	public BooleanProperty colorFromSegmentIdProperty()
+	{
+		return this.colorFromSegmentId;
 	}
 }

--- a/src/main/java/bdv/bigcat/viewer/stream/AbstractSaturatedHighlightingARGBStream.java
+++ b/src/main/java/bdv/bigcat/viewer/stream/AbstractSaturatedHighlightingARGBStream.java
@@ -40,9 +40,10 @@ abstract public class AbstractSaturatedHighlightingARGBStream extends AbstractHi
 	}
 
 	@Override
-	protected int argbImpl( final long fragmentId )
+	protected int argbImpl( final long fragmentId, final boolean colorFromSegmentId )
 	{
-		final long assigned = assignment.getSegment( fragmentId );
+		final boolean isActiveSegment = isActiveSegment( fragmentId );
+		final long assigned = colorFromSegmentId || !isActiveSegment ? assignment.getSegment( fragmentId ) : fragmentId;
 		if ( !argbCache.contains( assigned ) )
 		{
 			double x = getDouble( seed + assigned );
@@ -68,7 +69,7 @@ abstract public class AbstractSaturatedHighlightingARGBStream extends AbstractHi
 		if ( Label.INVALID == fragmentId )
 			argb = argb & 0x00ffffff | invalidSegmentAlpha;
 		else
-			argb = argb & 0x00ffffff | ( isActiveSegment( fragmentId ) ? isActiveFragment( fragmentId ) ? activeFragmentAlpha : activeSegmentAlpha : alpha );
+			argb = argb & 0x00ffffff | ( isActiveSegment ? isActiveFragment( fragmentId ) ? activeFragmentAlpha : activeSegmentAlpha : alpha );
 
 		return argb;
 	}

--- a/src/main/java/bdv/bigcat/viewer/stream/ColorFromSegmentId.java
+++ b/src/main/java/bdv/bigcat/viewer/stream/ColorFromSegmentId.java
@@ -1,0 +1,10 @@
+package bdv.bigcat.viewer.stream;
+
+import javafx.beans.property.BooleanProperty;
+
+public interface ColorFromSegmentId
+{
+
+	public BooleanProperty colorFromSegmentIdProperty();
+
+}

--- a/src/main/java/bdv/bigcat/viewer/stream/GoldenAngleSaturatedHighlightingARGBStream.java
+++ b/src/main/java/bdv/bigcat/viewer/stream/GoldenAngleSaturatedHighlightingARGBStream.java
@@ -39,7 +39,7 @@ public class GoldenAngleSaturatedHighlightingARGBStream extends AbstractSaturate
 	final static protected double goldenRatio = 1.0 / ( 0.5 * Math.sqrt( 5 ) + 0.5 );
 
 	@Override
-	final protected double getDoubleImpl( final long id )
+	final protected double getDoubleImpl( final long id, final boolean colorFromSegmentId )
 	{
 		final double x = id * seed * goldenRatio;
 		return x - ( long ) Math.floor( x );

--- a/src/main/java/bdv/bigcat/viewer/stream/HighlightingStreamConverter.java
+++ b/src/main/java/bdv/bigcat/viewer/stream/HighlightingStreamConverter.java
@@ -1,14 +1,16 @@
 package bdv.bigcat.viewer.stream;
 
 import bdv.labels.labelset.Label;
+import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.LongProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleIntegerProperty;
 import javafx.beans.property.SimpleLongProperty;
 import net.imglib2.converter.Converter;
 import net.imglib2.type.numeric.ARGBType;
 
-public abstract class HighlightingStreamConverter< T > implements Converter< T, ARGBType >, SeedProperty, WithAlpha
+public abstract class HighlightingStreamConverter< T > implements Converter< T, ARGBType >, SeedProperty, WithAlpha, ColorFromSegmentId
 {
 
 	protected final AbstractHighlightingARGBStream stream;
@@ -20,6 +22,8 @@ public abstract class HighlightingStreamConverter< T > implements Converter< T, 
 	private final IntegerProperty activeFragmentAlpha = new SimpleIntegerProperty();
 
 	private final IntegerProperty activeSegmentAlpha = new SimpleIntegerProperty();
+
+	private final BooleanProperty colorFromSegmentId = new SimpleBooleanProperty();
 
 	public HighlightingStreamConverter( final AbstractHighlightingARGBStream stream )
 	{
@@ -33,6 +37,7 @@ public abstract class HighlightingStreamConverter< T > implements Converter< T, 
 		alpha.set( stream.getAlpha() );
 		activeFragmentAlpha.set( stream.getActiveFragmentAlpha() );
 		activeSegmentAlpha.set( stream.getActiveSegmentAlpha() );
+		stream.colorFromSegmentIdProperty().bind( this.colorFromSegmentId );
 	}
 
 	private static long considerMaxUnsignedInt( final long val )
@@ -62,6 +67,12 @@ public abstract class HighlightingStreamConverter< T > implements Converter< T, 
 	public IntegerProperty activeSegmentAlphaProperty()
 	{
 		return this.activeSegmentAlpha;
+	}
+
+	@Override
+	public BooleanProperty colorFromSegmentIdProperty()
+	{
+		return this.colorFromSegmentId;
 	}
 
 }

--- a/src/main/java/bdv/bigcat/viewer/stream/ModalGoldenAngleSaturatedHighlightingARGBStream.java
+++ b/src/main/java/bdv/bigcat/viewer/stream/ModalGoldenAngleSaturatedHighlightingARGBStream.java
@@ -75,10 +75,11 @@ public class ModalGoldenAngleSaturatedHighlightingARGBStream extends GoldenAngle
 	}
 
 	@Override
-	protected int argbImpl( final long fragmentId )
+	protected int argbImpl( final long fragmentId, final boolean colorFromSegmentId )
 	{
 
-		final long assigned = assignment.getSegment( fragmentId );
+		final boolean isActiveSegment = isActiveSegment( fragmentId );
+		final long assigned = colorFromSegmentId || !isActiveSegment ? assignment.getSegment( fragmentId ) : fragmentId;
 
 		if ( !argbCache.contains( assigned ) )
 		{
@@ -106,7 +107,7 @@ public class ModalGoldenAngleSaturatedHighlightingARGBStream extends GoldenAngle
 		if ( Label.INVALID == fragmentId )
 			argb = argb & 0x00ffffff | invalidSegmentAlpha;
 		else
-			argb = argb & 0x00ffffff | ( isActiveSegment( fragmentId ) ? isActiveFragment( fragmentId ) ? activeFragmentAlpha : activeSegmentAlpha : alpha );
+			argb = argb & 0x00ffffff | ( isActiveSegment ? isActiveFragment( fragmentId ) ? activeFragmentAlpha : activeSegmentAlpha : alpha );
 
 		return argb;
 	}


### PR DESCRIPTION
This affects only any fragment that is within a currently active segment.
The rationale is that we can distinguish fragments within active segments from other fragments based on the active segment alpha. For fragments that are not part of an active segment it is impossible to tell which segment they belong to.