### PR TITLE
Export mesh feature

### DIFF
--- a/src/main/java/bdv/bigcat/viewer/atlas/Atlas.java
+++ b/src/main/java/bdv/bigcat/viewer/atlas/Atlas.java
@@ -515,7 +515,7 @@ public class Atlas
 				settings.meshSimplificationIterationsProperty(),
 				this.generalPurposeExecutorService );
 
-		final MeshInfos meshInfos = new MeshInfos( selectedSegments, assignment, meshManager, spec.getNumMipmapLevels() );
+		final MeshInfos meshInfos = new MeshInfos( state, selectedSegments, assignment, meshManager, spec.getNumMipmapLevels() );
 		state.meshManagerProperty().set( meshManager );
 		state.meshInfosProperty().set( meshInfos );
 
@@ -675,7 +675,7 @@ public class Atlas
 				settings.meshSimplificationIterationsProperty(),
 				this.generalPurposeExecutorService );
 
-		final MeshInfos meshInfos = new MeshInfos( selectedSegments, assignment, meshManager, spec.getNumMipmapLevels() );
+		final MeshInfos meshInfos = new MeshInfos( state, selectedSegments, assignment, meshManager, spec.getNumMipmapLevels() );
 		state.meshManagerProperty().set( meshManager );
 		state.meshInfosProperty().set( meshInfos );
 

--- a/src/main/java/bdv/bigcat/viewer/atlas/ui/source/mesh/ExportResult.java
+++ b/src/main/java/bdv/bigcat/viewer/atlas/ui/source/mesh/ExportResult.java
@@ -6,17 +6,19 @@ public class ExportResult
 {
 	private final MeshExporter meshExporter;
 
-	private final long segmentId;
+	private final long[] segmentId;
 
-	private final String filePath;
+	private final String[] filePaths;
 
 	private final int scale;
 
-	public ExportResult( final MeshExporter meshExporter, final long segmentId, final int scale, final String filePath )
+	// TODO: change scale parameter when the interface allows to export
+	// different scales for different meshes at the same time
+	public ExportResult( final MeshExporter meshExporter, final long[] segmentId, final int scale, final String[] filePaths )
 	{
 		this.meshExporter = meshExporter;
 		this.segmentId = segmentId;
-		this.filePath = filePath;
+		this.filePaths = filePaths;
 		this.scale = scale;
 	}
 
@@ -25,14 +27,14 @@ public class ExportResult
 		return meshExporter;
 	}
 
-	public long getSegmentId()
+	public long[] getSegmentId()
 	{
 		return segmentId;
 	}
 
-	public String getFilePath()
+	public String[] getFilePaths()
 	{
-		return filePath;
+		return filePaths;
 	}
 
 	public int getScale()

--- a/src/main/java/bdv/bigcat/viewer/atlas/ui/source/mesh/ExportResult.java
+++ b/src/main/java/bdv/bigcat/viewer/atlas/ui/source/mesh/ExportResult.java
@@ -1,0 +1,43 @@
+package bdv.bigcat.viewer.atlas.ui.source.mesh;
+
+import bdv.bigcat.viewer.meshes.MeshExporter;
+
+public class ExportResult
+{
+	private final MeshExporter meshExporter;
+
+	private final long segmentId;
+
+	private final String filePath;
+
+	private final int scale;
+
+	public ExportResult( final MeshExporter meshExporter, final long segmentId, final int scale, final String filePath )
+	{
+		this.meshExporter = meshExporter;
+		this.segmentId = segmentId;
+		this.filePath = filePath;
+		this.scale = scale;
+	}
+
+	public MeshExporter getMeshExporter()
+	{
+		return meshExporter;
+	}
+
+	public long getSegmentId()
+	{
+		return segmentId;
+	}
+
+	public String getFilePath()
+	{
+		return filePath;
+	}
+
+	public int getScale()
+	{
+		return scale;
+	}
+
+}

--- a/src/main/java/bdv/bigcat/viewer/atlas/ui/source/mesh/MeshExporterDialog.java
+++ b/src/main/java/bdv/bigcat/viewer/atlas/ui/source/mesh/MeshExporterDialog.java
@@ -132,14 +132,12 @@ public class MeshExporterDialog extends Dialog< ExportResult >
 			Optional.ofNullable( directory ).map( File::getAbsolutePath );
 			filePath.setText( directory.getPath() );
 
-			String extension = getExtension( fileFormats );
-
 			for ( int i = 0; i < segmentIds.length; i++ )
 			{
-				filePaths[ i ] = directory + "/neuron" + segmentIds[ i ] + extension;
+				filePaths[ i ] = directory + "/neuron" + segmentIds[ i ];
 			}
 
-			createMeshExporter( extension );
+			createMeshExporter( fileFormats.getSelectionModel().getSelectedItem() );
 		} );
 
 		contents.add( button, 2, row );
@@ -181,14 +179,12 @@ public class MeshExporterDialog extends Dialog< ExportResult >
 
 			segmentIds = selectedIds.stream().mapToLong( l -> l ).toArray();
 
-			String extension = getExtension( fileFormats );
-
 			for ( int i = 0; i < selectedIds.size(); i++ )
 			{
-				filePaths[ i ] = directory + "/neuron" + selectedIds.get( i ) + extension;
+				filePaths[ i ] = directory + "/neuron" + selectedIds.get( i );
 			}
 
-			createMeshExporter( extension );
+			createMeshExporter( fileFormats.getSelectionModel().getSelectedItem() );
 		} );
 
 		contents.add( button, 2, row );
@@ -232,18 +228,11 @@ public class MeshExporterDialog extends Dialog< ExportResult >
 		return row;
 	}
 
-	private String getExtension( ComboBox< String > fileFormats )
+	private void createMeshExporter( String filetype )
 	{
-		if ( fileFormats.getSelectionModel().getSelectedIndex() == 0 ) { return ".obj"; }
-
-		return ".bin";
-	}
-
-	private void createMeshExporter( String extension )
-	{
-		switch ( extension )
+		switch ( filetype )
 		{
-		case ".bin":
+		case "binary":
 			meshExporter = new MeshExporterBinary();
 			break;
 		case ".obj":

--- a/src/main/java/bdv/bigcat/viewer/atlas/ui/source/mesh/MeshExporterDialog.java
+++ b/src/main/java/bdv/bigcat/viewer/atlas/ui/source/mesh/MeshExporterDialog.java
@@ -1,0 +1,144 @@
+package bdv.bigcat.viewer.atlas.ui.source.mesh;
+
+import java.io.File;
+import java.util.Optional;
+
+import org.controlsfx.control.StatusBar;
+
+import bdv.bigcat.viewer.meshes.MeshExporter;
+import bdv.bigcat.viewer.meshes.MeshExporterBinary;
+import bdv.bigcat.viewer.meshes.MeshExporterObj;
+import bdv.bigcat.viewer.meshes.MeshInfo;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.scene.control.Button;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Dialog;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
+import javafx.scene.control.TitledPane;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.VBox;
+import javafx.stage.DirectoryChooser;
+
+public class MeshExporterDialog extends Dialog< ExportResult >
+{
+	private final TextField scale;
+
+	private MeshExporter meshExporter;
+
+	private final long segmentId;
+
+	private final TextField filePath;
+
+	public MeshExporterDialog( final MeshInfo meshInfo )
+	{
+		super();
+		this.setTitle( "Export mesh..." );
+		this.segmentId = meshInfo.segmentId();
+		this.filePath = new TextField();
+		scale = new TextField( Integer.toString( meshInfo.scaleLevelProperty().get() ) );
+
+		setNumericTextField( scale, meshInfo.numScaleLevels() - 1 );
+		setResultConverter( button -> {
+			if ( button.getButtonData().isCancelButton() )
+				return null;
+			// here you can also check what button was pressed
+			// and return things accordingly
+			return new ExportResult( meshExporter, segmentId, Integer.parseInt( scale.getText() ), filePath.getText() );
+		} );
+
+		createDialog();
+
+	}
+
+	private void createDialog()
+	{
+		final VBox vbox = new VBox();
+		final TitledPane pane = new TitledPane( null, vbox );
+
+		final StatusBar statusBar = new StatusBar();
+		// TODO come up with better way to ensure proper size of this!
+		statusBar.setMinWidth( 200 );
+		statusBar.setMaxWidth( 200 );
+		statusBar.setPrefWidth( 200 );
+		statusBar.setText( "Export mesh" );
+		pane.setGraphic( statusBar );
+
+		final GridPane contents = new GridPane();
+
+		int row = 0;
+
+		contents.add( new Label( "Scale" ), 0, row );
+		contents.add( scale, 1, row );
+		++row;
+
+		contents.add( new Label( "Format" ), 0, row );
+
+		ObservableList< String > options = FXCollections.observableArrayList( ".obj", "binary" );
+		final ComboBox< String > formats = new ComboBox<>(options);
+		formats.getSelectionModel().select( 0 );
+		contents.add( formats, 1, row );
+		++row;
+		
+		contents.add( new Label( "Directory" ), 0, row );
+		contents.add( filePath, 1, row );
+
+		final Button button = new Button( "Save to..." );
+		button.setOnAction( event -> {
+			final DirectoryChooser directoryChooser = new DirectoryChooser();
+			final File directory = directoryChooser.showDialog( contents.getScene().getWindow() );
+			Optional.ofNullable( directory ).map( File::getAbsolutePath );
+
+			String filename = directory + "/neuron" + segmentId;
+			if ( formats.getSelectionModel().getSelectedIndex() == 0 )
+			{
+				filename = filename.concat( ".obj" );
+				meshExporter = new MeshExporterObj();
+			}
+			else
+			{
+				filename = filename.concat( ".bin" );
+				meshExporter = new MeshExporterBinary();
+			}
+
+			filePath.setText( filename );
+
+		} );
+
+		contents.add( button, 2, row );
+		++row;
+
+		vbox.getChildren().add( contents );
+
+		this.getDialogPane().setContent( vbox );
+		this.getDialogPane().getButtonTypes().addAll( ButtonType.CANCEL, ButtonType.OK );
+
+	}
+
+	private void setNumericTextField( final TextField textField, final int max )
+	{
+		// force the field to be numeric only
+		textField.textProperty().addListener( new ChangeListener< String >()
+		{
+			@Override
+			public void changed( ObservableValue< ? extends String > observable, String oldValue,
+					String newValue )
+			{
+				if ( !newValue.matches( "\\d*" ) )
+				{
+					textField.setText( newValue.replaceAll( "[^\\d]", "" ) );
+				}
+
+				if ( Integer.parseInt( textField.getText() ) > max )
+				{
+					textField.setText( Integer.toString( max ) );
+				}
+			}
+		} );
+
+	}
+}

--- a/src/main/java/bdv/bigcat/viewer/atlas/ui/source/mesh/MeshExporterDialog.java
+++ b/src/main/java/bdv/bigcat/viewer/atlas/ui/source/mesh/MeshExporterDialog.java
@@ -46,8 +46,6 @@ public class MeshExporterDialog extends Dialog< ExportResult >
 		setResultConverter( button -> {
 			if ( button.getButtonData().isCancelButton() )
 				return null;
-			// here you can also check what button was pressed
-			// and return things accordingly
 			return new ExportResult( meshExporter, segmentId, Integer.parseInt( scale.getText() ), filePath.getText() );
 		} );
 

--- a/src/main/java/bdv/bigcat/viewer/atlas/ui/source/mesh/MeshInfoNode.java
+++ b/src/main/java/bdv/bigcat/viewer/atlas/ui/source/mesh/MeshInfoNode.java
@@ -123,13 +123,13 @@ public class MeshInfoNode implements BindUnbindAndNodeSupplier
 
 		final Button exportMeshButton = new Button( "Export" );
 		exportMeshButton.setOnAction( event -> {
-			System.out.println( "pressed button" );
 			MeshExporterDialog exportDialog = new MeshExporterDialog( meshInfo );
 			final Optional< ExportResult > result = exportDialog.showAndWait();
 			if ( result.isPresent() )
 			{
 				ExportResult parameters = result.get();
-				parameters.getMeshExporter().exportMesh( meshInfo.state(), parameters.getSegmentId(), parameters.getScale(), parameters.getFilePath() );
+				assert ( parameters.getSegmentId().length == 1 );
+				parameters.getMeshExporter().exportMesh( meshInfo.state(), parameters.getSegmentId()[ 0 ], parameters.getScale(), parameters.getFilePaths()[ 0 ] );
 			}
 		} );
 		contents.add( exportMeshButton, 2, row );

--- a/src/main/java/bdv/bigcat/viewer/atlas/ui/source/mesh/MeshInfoNode.java
+++ b/src/main/java/bdv/bigcat/viewer/atlas/ui/source/mesh/MeshInfoNode.java
@@ -1,9 +1,11 @@
 package bdv.bigcat.viewer.atlas.ui.source.mesh;
 
 import java.util.Arrays;
+import java.util.Optional;
 
 import org.controlsfx.control.StatusBar;
 
+import bdv.bigcat.viewer.atlas.source.AtlasSourceState;
 import bdv.bigcat.viewer.atlas.ui.BindUnbindAndNodeSupplier;
 import bdv.bigcat.viewer.meshes.MeshInfo;
 import bdv.bigcat.viewer.meshes.MeshManager;
@@ -15,6 +17,7 @@ import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.SimpleIntegerProperty;
 import javafx.scene.Node;
+import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.TitledPane;
 import javafx.scene.control.Tooltip;
@@ -45,9 +48,9 @@ public class MeshInfoNode implements BindUnbindAndNodeSupplier
 		this.contents = createContents();
 	}
 
-	public MeshInfoNode( final long segmentId, final FragmentSegmentAssignment assignment, final MeshManager meshManager, final int numScaleLevels )
+	public MeshInfoNode( final AtlasSourceState< ?, ? > state, final long segmentId, final FragmentSegmentAssignment assignment, final MeshManager meshManager, final int numScaleLevels )
 	{
-		this( new MeshInfo( segmentId, assignment, meshManager, numScaleLevels ) );
+		this( new MeshInfo( state, segmentId, assignment, meshManager, numScaleLevels ) );
 	}
 
 	@Override
@@ -116,6 +119,20 @@ public class MeshInfoNode implements BindUnbindAndNodeSupplier
 		contents.add( simplificationSlider.textField(), 2, row );
 		simplificationSlider.slider().setShowTickLabels( true );
 		simplificationSlider.slider().setTooltip( new Tooltip( "Simplify meshes n times." ) );
+		++row;
+
+		final Button exportMeshButton = new Button( "Export" );
+		exportMeshButton.setOnAction( event -> {
+			System.out.println( "pressed button" );
+			MeshExporterDialog exportDialog = new MeshExporterDialog( meshInfo );
+			final Optional< ExportResult > result = exportDialog.showAndWait();
+			if ( result.isPresent() )
+			{
+				ExportResult parameters = result.get();
+				parameters.getMeshExporter().exportMesh( meshInfo.state(), parameters.getSegmentId(), parameters.getScale(), parameters.getFilePath() );
+			}
+		} );
+		contents.add( exportMeshButton, 2, row );
 		++row;
 
 		vbox.getChildren().add( contents );

--- a/src/main/java/bdv/bigcat/viewer/meshes/MeshExporter.java
+++ b/src/main/java/bdv/bigcat/viewer/meshes/MeshExporter.java
@@ -1,0 +1,82 @@
+package bdv.bigcat.viewer.meshes;
+
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import bdv.bigcat.viewer.atlas.source.AtlasSourceState;
+import bdv.bigcat.viewer.meshes.MeshGenerator.ShapeKey;
+import net.imglib2.Interval;
+import net.imglib2.cache.Cache;
+import net.imglib2.util.Intervals;
+import net.imglib2.util.Pair;
+
+public abstract class MeshExporter
+{
+	private static final Logger LOG = LoggerFactory.getLogger( MethodHandles.lookup().lookupClass() );
+
+	public void exportMeshes( final AtlasSourceState< ?, ? > state, final long[] ids, final int[] scales, final int[] simplificationIterations, String[] paths )
+	{
+		assert ids.length == scales.length;
+		for ( int i = 0; i < ids.length; i++ )
+		{
+			exportMesh( state, ids[ i ], scales[ i ], simplificationIterations[ i ], paths[ i ] );
+		}
+	}
+
+	public void exportMesh( final AtlasSourceState< ?, ? > state, final long id, final int scaleIndex, final int simplificationIterations, String path )
+	{
+		final Cache< Long, Interval[] >[] blockListCache = state.blocklistCacheProperty().get();
+		final Cache< ShapeKey, Pair< float[], float[] > >[] meshCache = state.meshesCacheProperty().get();
+		// all blocks from id
+		Interval[] blocks = null;
+		try
+		{
+			blocks = blockListCache[ scaleIndex ].get( id );
+		}
+		catch ( ExecutionException e )
+		{
+			LOG.warn( "Could not get mesh block list for id {}: {}", id,
+					e.getMessage() );
+		}
+
+		// generate keys from blocks, scaleIndex, and id
+		final List< ShapeKey > keys = new ArrayList<>();
+		for ( final Interval block : blocks )
+			keys.add( new ShapeKey( id, scaleIndex, simplificationIterations, Intervals.minAsLongArray( block ), Intervals.maxAsLongArray( block ) ) );
+
+		float[] allVertices = null;
+		float[] allNormals = null;
+		for ( final ShapeKey key : keys )
+		{
+			Pair< float[], float[] > verticesAndNormals;
+			try
+			{
+				verticesAndNormals = meshCache[ scaleIndex ].get( key );
+				allVertices = ArrayUtils.addAll( allVertices, verticesAndNormals.getA() );
+				allNormals = ArrayUtils.addAll( allNormals, verticesAndNormals.getB() );
+			}
+			catch ( final ExecutionException e )
+			{
+				LOG.warn( "Was not able to retrieve mesh for {}: {}", key, e.getMessage() );
+			}
+			catch ( final RuntimeException e )
+			{
+				LOG.warn( "{} : {}", e.getClass(), e.getMessage() );
+				e.printStackTrace();
+				throw e;
+			}
+		}
+
+		assert allVertices.length == allNormals.length: "Vertices and normals must have the same size.";
+		save( path, id, allVertices, allNormals );
+	}
+
+	protected abstract void save( String path, long id, float[] vertices, float[] normals );
+
+}

--- a/src/main/java/bdv/bigcat/viewer/meshes/MeshExporter.java
+++ b/src/main/java/bdv/bigcat/viewer/meshes/MeshExporter.java
@@ -25,11 +25,11 @@ public abstract class MeshExporter
 		assert ids.length == scales.length;
 		for ( int i = 0; i < ids.length; i++ )
 		{
-			exportMesh( state, ids[ i ], scales[ i ], simplificationIterations[ i ], paths[ i ] );
+			exportMesh( state, ids[ i ], scales[ i ], paths[ i ] );
 		}
 	}
 
-	public void exportMesh( final AtlasSourceState< ?, ? > state, final long id, final int scaleIndex, final int simplificationIterations, String path )
+	public void exportMesh( final AtlasSourceState< ?, ? > state, final long id, final int scaleIndex, String path )
 	{
 		final Cache< Long, Interval[] >[] blockListCache = state.blocklistCacheProperty().get();
 		final Cache< ShapeKey, Pair< float[], float[] > >[] meshCache = state.meshesCacheProperty().get();
@@ -48,7 +48,8 @@ public abstract class MeshExporter
 		// generate keys from blocks, scaleIndex, and id
 		final List< ShapeKey > keys = new ArrayList<>();
 		for ( final Interval block : blocks )
-			keys.add( new ShapeKey( id, scaleIndex, simplificationIterations, Intervals.minAsLongArray( block ), Intervals.maxAsLongArray( block ) ) );
+			// ignoring simplification iterations parameter
+			keys.add( new ShapeKey( id, scaleIndex, 0, Intervals.minAsLongArray( block ), Intervals.maxAsLongArray( block ) ) );
 
 		float[] allVertices = null;
 		float[] allNormals = null;

--- a/src/main/java/bdv/bigcat/viewer/meshes/MeshExporter.java
+++ b/src/main/java/bdv/bigcat/viewer/meshes/MeshExporter.java
@@ -20,12 +20,12 @@ public abstract class MeshExporter
 {
 	private static final Logger LOG = LoggerFactory.getLogger( MethodHandles.lookup().lookupClass() );
 
-	public void exportMeshes( final AtlasSourceState< ?, ? > state, final long[] ids, final int[] scales, final int[] simplificationIterations, String[] paths )
+	public void exportMesh( final AtlasSourceState< ?, ? >[] state, final long[] ids, final int scale, String[] paths )
 	{
-		assert ids.length == scales.length;
+		assert ids.length == paths.length;
 		for ( int i = 0; i < ids.length; i++ )
 		{
-			exportMesh( state, ids[ i ], scales[ i ], paths[ i ] );
+			exportMesh( state[ i ], ids[ i ], scale, paths[ i ] );
 		}
 	}
 

--- a/src/main/java/bdv/bigcat/viewer/meshes/MeshExporterBinary.java
+++ b/src/main/java/bdv/bigcat/viewer/meshes/MeshExporterBinary.java
@@ -1,0 +1,52 @@
+package bdv.bigcat.viewer.meshes;
+
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.invoke.MethodHandles;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MeshExporterBinary extends MeshExporter
+{
+	private static final Logger LOG = LoggerFactory.getLogger( MethodHandles.lookup().lookupClass() );
+
+	@Override
+	protected void save( String path, long id, float[] vertices, float[] normals )
+	{
+		try
+		{
+			OutputStream outputStream = new FileOutputStream( path );
+
+			final StringBuilder sb = new StringBuilder();
+			for ( int i = 0; i < vertices.length; i += 3 )
+			{
+				sb.append( "\n " ).append( vertices[ i ] ).append( " " ).append( vertices[ i + 1 ] ).append( " " ).append( vertices[ i + 2 ] );
+			}
+
+			sb.append( "\n" );
+			for ( int i = 0; i < normals.length; i += 3 )
+			{
+				sb.append( "\n " ).append( normals[ i ] ).append( " " ).append( normals[ i + 1 ] ).append( " " ).append( normals[ i + 2 ] );
+			}
+
+			try
+			{
+				outputStream.write( sb.toString().getBytes() );
+				outputStream.close();
+			}
+			catch ( IOException e )
+			{
+				LOG.warn( "Couldn't write data to the file {}: {}", path, e.getMessage() );
+			}
+
+		}
+		catch ( FileNotFoundException e )
+		{
+			LOG.warn( "Couldn't find file {}: {}", path, e.getMessage() );
+		}
+	}
+
+}

--- a/src/main/java/bdv/bigcat/viewer/meshes/MeshExporterBinary.java
+++ b/src/main/java/bdv/bigcat/viewer/meshes/MeshExporterBinary.java
@@ -14,22 +14,22 @@ public class MeshExporterBinary extends MeshExporter
 	private static final Logger LOG = LoggerFactory.getLogger( MethodHandles.lookup().lookupClass() );
 
 	@Override
-	protected void save( String path, long id, float[] vertices, float[] normals )
+	protected void save( String path, long id, float[] vertices, float[] normals, boolean append )
 	{
 		try
 		{
-			OutputStream outputStream = new FileOutputStream( path );
+			OutputStream outputStream = new FileOutputStream( path, append );
 
 			final StringBuilder sb = new StringBuilder();
 			for ( int i = 0; i < vertices.length; i += 3 )
 			{
-				sb.append( "\n " ).append( vertices[ i ] ).append( " " ).append( vertices[ i + 1 ] ).append( " " ).append( vertices[ i + 2 ] );
+				sb.append( "\nv " ).append( vertices[ i ] ).append( " " ).append( vertices[ i + 1 ] ).append( " " ).append( vertices[ i + 2 ] );
 			}
 
 			sb.append( "\n" );
 			for ( int i = 0; i < normals.length; i += 3 )
 			{
-				sb.append( "\n " ).append( normals[ i ] ).append( " " ).append( normals[ i + 1 ] ).append( " " ).append( normals[ i + 2 ] );
+				sb.append( "\nvn " ).append( normals[ i ] ).append( " " ).append( normals[ i + 1 ] ).append( " " ).append( normals[ i + 2 ] );
 			}
 
 			try

--- a/src/main/java/bdv/bigcat/viewer/meshes/MeshExporterBinary.java
+++ b/src/main/java/bdv/bigcat/viewer/meshes/MeshExporterBinary.java
@@ -1,9 +1,10 @@
 package bdv.bigcat.viewer.meshes;
 
+import java.io.BufferedOutputStream;
+import java.io.DataOutputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.lang.invoke.MethodHandles;
 
 import org.slf4j.Logger;
@@ -16,32 +17,27 @@ public class MeshExporterBinary extends MeshExporter
 	@Override
 	protected void save( String path, long id, float[] vertices, float[] normals, boolean append )
 	{
+		save( path + ".vertices", vertices, append );
+		save( path + ".normals", normals, append );
+	}
+
+	private void save( String path, float[] info, boolean append )
+	{
 		try
 		{
-			OutputStream outputStream = new FileOutputStream( path, append );
-
-			final StringBuilder sb = new StringBuilder();
-			for ( int i = 0; i < vertices.length; i += 3 )
-			{
-				sb.append( "\nv " ).append( vertices[ i ] ).append( " " ).append( vertices[ i + 1 ] ).append( " " ).append( vertices[ i + 2 ] );
-			}
-
-			sb.append( "\n" );
-			for ( int i = 0; i < normals.length; i += 3 )
-			{
-				sb.append( "\nvn " ).append( normals[ i ] ).append( " " ).append( normals[ i + 1 ] ).append( " " ).append( normals[ i + 2 ] );
-			}
-
+			DataOutputStream stream = new DataOutputStream( new BufferedOutputStream( new FileOutputStream( path, append ) ) );
 			try
 			{
-				outputStream.write( sb.toString().getBytes() );
-				outputStream.close();
+				for ( int i = 0; i < info.length; i++ )
+				{
+					stream.writeFloat( info[ i ] );
+				}
+				stream.close();
 			}
 			catch ( IOException e )
 			{
 				LOG.warn( "Couldn't write data to the file {}: {}", path, e.getMessage() );
 			}
-
 		}
 		catch ( FileNotFoundException e )
 		{

--- a/src/main/java/bdv/bigcat/viewer/meshes/MeshExporterObj.java
+++ b/src/main/java/bdv/bigcat/viewer/meshes/MeshExporterObj.java
@@ -1,0 +1,65 @@
+package bdv.bigcat.viewer.meshes;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MeshExporterObj extends MeshExporter
+{
+	private static final Logger LOG = LoggerFactory.getLogger( MethodHandles.lookup().lookupClass() );
+
+	@Override
+	protected void save( String path, long id, float[] vertices, float[] normals )
+	{
+		final File file = new File( path );
+		try
+		{
+			FileWriter writer = new FileWriter( file );
+			float[] texCoords = new float[] { 0.0f, 0.0f };
+			final StringBuilder sb = new StringBuilder().append( "# id: " ).append( id ).append( "\n" );
+
+			sb.append( "\n" );
+			final int numVertices = vertices.length;
+			for ( int k = 0; k < numVertices; k += 3 )
+				sb.append( "\nv " ).append( vertices[ k + 0 ] ).append( " " ).append( vertices[ k + 1 ] ).append( " " ).append( vertices[ k + 2 ] );
+
+			sb.append( "\n" );
+			final int numNormals = normals.length;
+			for ( int k = 0; k < numNormals; k += 3 )
+				sb.append( "\nvn " ).append( normals[ k + 0 ] ).append( " " ).append( normals[ k + 1 ] ).append( " " ).append( normals[ k + 2 ] );
+
+			sb.append( "\n" );
+			final int numTexCoords = texCoords.length;
+			for ( int k = 0; k < numTexCoords; k += 2 )
+				sb.append( "\nvt " ).append( texCoords[ k + 0 ] ).append( " " ).append( texCoords[ k + 1 ] );
+
+			sb.append( "\n" );
+			for ( int k = 0; k < numVertices / 3; k += 3 )
+			{
+				sb
+						.append( "\nf " ).append( k + 1 ).append( "/" ).append( 1 ).append( "/" ).append( k + 1 )
+						.append( " " ).append( k + 2 ).append( "/" ).append( 1 ).append( "/" ).append( k + 2 )
+						.append( " " ).append( k + 3 ).append( "/" ).append( 1 ).append( "/" ).append( k + 3 );
+			}
+
+			try
+			{
+				writer.write( sb.toString() );
+				writer.close();
+			}
+			catch ( final IOException e )
+			{
+				LOG.warn( "Couldn't write data to the file {}: {}", file.toPath(), e.getMessage() );
+			}
+
+		}
+		catch ( IOException e )
+		{
+			LOG.warn( "Couldn't open the file {}: {}", file.toPath(), e.getMessage() );
+		}
+	}
+}

--- a/src/main/java/bdv/bigcat/viewer/meshes/MeshExporterObj.java
+++ b/src/main/java/bdv/bigcat/viewer/meshes/MeshExporterObj.java
@@ -1,6 +1,5 @@
 package bdv.bigcat.viewer.meshes;
 
-import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
@@ -13,16 +12,18 @@ public class MeshExporterObj extends MeshExporter
 	private static final Logger LOG = LoggerFactory.getLogger( MethodHandles.lookup().lookupClass() );
 
 	@Override
-	protected void save( String path, long id, float[] vertices, float[] normals )
+	protected void save( String path, long id, float[] vertices, float[] normals, boolean append )
 	{
-		final File file = new File( path );
+
 		try
 		{
-			FileWriter writer = new FileWriter( file );
+			FileWriter writer = new FileWriter( path, append );
 			float[] texCoords = new float[] { 0.0f, 0.0f };
-			final StringBuilder sb = new StringBuilder().append( "# id: " ).append( id ).append( "\n" );
+			final StringBuilder sb = new StringBuilder();
 
-			sb.append( "\n" );
+			if ( !append )
+				sb.append( "# id: " ).append( id ).append( "\n" );
+
 			final int numVertices = vertices.length;
 			for ( int k = 0; k < numVertices; k += 3 )
 				sb.append( "\nv " ).append( vertices[ k + 0 ] ).append( " " ).append( vertices[ k + 1 ] ).append( " " ).append( vertices[ k + 2 ] );
@@ -40,26 +41,25 @@ public class MeshExporterObj extends MeshExporter
 			sb.append( "\n" );
 			for ( int k = 0; k < numVertices / 3; k += 3 )
 			{
-				sb
-						.append( "\nf " ).append( k + 1 ).append( "/" ).append( 1 ).append( "/" ).append( k + 1 )
-						.append( " " ).append( k + 2 ).append( "/" ).append( 1 ).append( "/" ).append( k + 2 )
-						.append( " " ).append( k + 3 ).append( "/" ).append( 1 ).append( "/" ).append( k + 3 );
+				sb.append( "\nf " ).append( k + numberOfFaces + 1 ).append( "/" ).append( 1 ).append( "/" ).append( k + numberOfFaces + 1 )
+						.append( " " ).append( k + numberOfFaces + 2 ).append( "/" ).append( 1 ).append( "/" ).append( k + numberOfFaces + 2 )
+						.append( " " ).append( k + numberOfFaces + 3 ).append( "/" ).append( 1 ).append( "/" ).append( k + numberOfFaces + 3 );
 			}
 
 			try
 			{
-				writer.write( sb.toString() );
+				writer.append( sb.toString() );
 				writer.close();
 			}
 			catch ( final IOException e )
 			{
-				LOG.warn( "Couldn't write data to the file {}: {}", file.toPath(), e.getMessage() );
+				LOG.warn( "Couldn't write data to the file {}: {}", path, e.getMessage() );
 			}
 
 		}
 		catch ( IOException e )
 		{
-			LOG.warn( "Couldn't open the file {}: {}", file.toPath(), e.getMessage() );
+			LOG.warn( "Couldn't open the file {}: {}", path, e.getMessage() );
 		}
 	}
 }

--- a/src/main/java/bdv/bigcat/viewer/meshes/MeshExporterObj.java
+++ b/src/main/java/bdv/bigcat/viewer/meshes/MeshExporterObj.java
@@ -14,7 +14,7 @@ public class MeshExporterObj extends MeshExporter
 	@Override
 	protected void save( String path, long id, float[] vertices, float[] normals, boolean append )
 	{
-
+		path = path + ".obj";
 		try
 		{
 			FileWriter writer = new FileWriter( path, append );

--- a/src/main/java/bdv/bigcat/viewer/meshes/MeshInfo.java
+++ b/src/main/java/bdv/bigcat/viewer/meshes/MeshInfo.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
 
+import bdv.bigcat.viewer.atlas.source.AtlasSourceState;
 import bdv.bigcat.viewer.state.FragmentSegmentAssignment;
 import bdv.bigcat.viewer.state.FragmentSegmentAssignmentState;
 import javafx.beans.binding.Bindings;
@@ -21,6 +22,8 @@ public class MeshInfo
 
 	private final IntegerProperty simplificationIterations = new SimpleIntegerProperty();
 
+	private final AtlasSourceState< ?, ? > state;
+
 	private final long segmentId;
 
 	private final FragmentSegmentAssignment assignment;
@@ -35,9 +38,10 @@ public class MeshInfo
 
 	private final IntegerProperty successfulTasks = new SimpleIntegerProperty( 0 );
 
-	public MeshInfo( final long segmentId, final FragmentSegmentAssignment assignment, final MeshManager meshManager, final int numScaleLevels )
+	public MeshInfo( final AtlasSourceState< ?, ? > state, final long segmentId, final FragmentSegmentAssignment assignment, final MeshManager meshManager, final int numScaleLevels )
 	{
 		super();
+		this.state = state;
 		this.segmentId = segmentId;
 		this.assignment = assignment;
 		this.meshManager = meshManager;
@@ -70,6 +74,11 @@ public class MeshInfo
 		this.completedTasks.bind( Bindings.createIntegerBinding( () -> Arrays.stream( completedTasks ).mapToInt( ObservableIntegerValue::get ).sum(), completedTasks ) );
 		this.successfulTasks.bind( Bindings.createIntegerBinding( () -> Arrays.stream( submittedTasks ).mapToInt( ObservableIntegerValue::get ).sum(), successfulTasks ) );
 
+	}
+
+	public AtlasSourceState< ?, ? > state()
+	{
+		return this.state;
 	}
 
 	public long segmentId()

--- a/src/main/java/bdv/bigcat/viewer/meshes/MeshInfos.java
+++ b/src/main/java/bdv/bigcat/viewer/meshes/MeshInfos.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import bdv.bigcat.viewer.atlas.source.AtlasSourceState;
 import bdv.bigcat.viewer.state.FragmentSegmentAssignment;
 import bdv.bigcat.viewer.state.SelectedSegments;
 import javafx.collections.FXCollections;
@@ -17,6 +18,7 @@ public class MeshInfos
 	private final ObservableList< MeshInfo > readOnlyInfos = FXCollections.unmodifiableObservableList( infos );
 
 	public MeshInfos(
+			final AtlasSourceState< ?, ? > state,
 			final SelectedSegments< ? > selectedSegments,
 			final FragmentSegmentAssignment assignment,
 			final MeshManager meshManager,
@@ -28,7 +30,7 @@ public class MeshInfos
 			final long[] segments = selectedSegments.getSelectedSegments();
 			final List< MeshInfo > infos = Arrays
 					.stream( segments )
-					.mapToObj( id -> new MeshInfo( id, assignment, meshManager, numScaleLevels ) )
+					.mapToObj( id -> new MeshInfo( state, id, assignment, meshManager, numScaleLevels ) )
 					.collect( Collectors.toList() );
 
 			this.infos.setAll( infos );


### PR DESCRIPTION
Add feature to export 3d mesh.
We can export the mesh to an obj or binary formats. The binary format is right now just the vertices and normals information. I will check the .blender binary format to use it instead.
We have an "export" button for each mesh and an "export all" button (where the user can choose the indices that will be exported). However, right now, we need to use the same configuration (file format and scale, for instance) for all the meshes.