### PR TITLE
Fix initialization of canvasDimensions

### DIFF
--- a/src/main/java/bdv/bigcat/BigCat.java
+++ b/src/main/java/bdv/bigcat/BigCat.java
@@ -196,8 +196,8 @@ public class BigCat< P extends BigCat.Parameters > extends BigCatViewer< P >
 		else
 		{
 			final long[] canvasDimensions;
-			if ( params.labels.size() > 0 )
-				canvasDimensions = AbstractH5SetupImageLoader.readDimension( reader, params.labels.get( 0 ) );
+			if ( params.raws.size() > 0 )
+				canvasDimensions = AbstractH5SetupImageLoader.readDimension( reader, params.raws.get( 0 ) );
 			else
 				canvasDimensions = maxRawDimensions;
 


### PR DESCRIPTION
Hi everyone,
here is a fix for a small issue, I've experienced while trying BigCat on one of my datasets:
Given that raw data and labels are stored in a separate H5 files, [BigCat#initCanvas](https://github.com/saalfeldlab/bigcat/blob/master/src/main/java/bdv/bigcat/BigCat.java#L188) fails cause it's trying to init the `canvasDimensions` using the raw data file (`params.inFile`) and labels dataset path (`params.labels`) instead of raw dataset path (`params.raws`).
The `canvasDimensions` should be initialized either using: `params.inFile` + `params.raws` or `params.inFileLables` + `params.labels`.