### PR TITLE
Add conda install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # BIGCAT (working title)
 
+## Install
+
+BigCAT is available on conda:
+```shell
+conda install -c hanslovsky bigcat
+```
+Alternatively, you can run the `install` script (Linux only).
+
 ## Compile
 
 To compile a "fat jar" with all dependencies added, run:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ BigCAT is available on conda:
 ```shell
 conda install -c hanslovsky bigcat
 ```
-Alternatively, you can run the `install` script (Linux only).
+Alternatively, you can run the `install` script.
 
 ## Compile
 


### PR DESCRIPTION
 - Add instructions for conda install
 - Potentially renders `install` script obsolete
   - If true, fixes #106 

https://github.com/hanslovsky/conda-build-scripts/tree/master/bigcat