### PR TITLE
Add macOS support to the install script

### DIFF
--- a/install
+++ b/install
@@ -7,15 +7,28 @@ echo "Installing into $INSTALL_DIR"
 mvn clean install
 mvn -Dmdep.outputFile=cp.txt -Dmdep.includeScope=runtime dependency:build-classpath
 
-MEM=$(cat /proc/meminfo | grep MemTotal | sed s/^MemTotal:\\\s*\\\|\\\s\\+[^\\\s]*$//g)
-MEM=$(($MEM/2/1024/1024))
+# Use half of the available physical RAM.
+case "$(uname)" in
+'Linux')
+    MAX_MEM_BYTES="$(awk '/MemTotal/ {print 1024 * $2}' /proc/meminfo)"
+    ;;
+'Darwin')
+    MAX_MEM_BYTES="$(sysctl -n hw.memsize)"
+    ;;
+*)
+    echo 'WARNING: unknown OS, assuming 4 GB total physical RAM' 1>&2
+    MAX_MEM_BYTES="$(expr 4 '*' 1024 '*' 1024 '*' 1024)"
+    ;;
+esac
+MAX_MEM_BYTES="$(expr $MAX_MEM_BYTES / 2)"
 
+# Create a launch script.
 cat << EOF > bigcat
 #!/bin/bash
 
 JAR="\$HOME/.m2/repository/sc/fiji/bigcat/0.0.4-SNAPSHOT/bigcat-0.0.4-SNAPSHOT.jar"
 java \\
-  -Xmx${MEM}g \\
+  -Xmx$MAX_MEM_BYTES \\
   -XX:+UseConcMarkSweepGC \\
   -cp "\$JAR:$(cat cp.txt)" \\
   bdv.bigcat.BigCat "\$@"

--- a/install
+++ b/install
@@ -10,16 +10,16 @@ mvn -Dmdep.outputFile=cp.txt -Dmdep.includeScope=runtime dependency:build-classp
 MEM=$(cat /proc/meminfo | grep MemTotal | sed s/^MemTotal:\\\s*\\\|\\\s\\+[^\\\s]*$//g)
 MEM=$(($MEM/2/1024/1024))
 
-echo '#!/bin/bash' > bigcat
-echo '' >> bigcat
-echo 'JAR=$HOME/.m2/repository/sc/fiji/bigcat/0.0.4-SNAPSHOT/bigcat-0.0.4-SNAPSHOT.jar' >> bigcat
-echo 'java \' >> bigcat
-echo "  -Xmx${MEM}g \\" >> bigcat
-echo '  -XX:+UseConcMarkSweepGC \' >> bigcat
-echo -n '  -cp $JAR:' >> bigcat
-echo -n $(cat cp.txt) >> bigcat
-echo ' \' >> bigcat
-echo '  bdv.bigcat.BigCat $@' >> bigcat
+cat << EOF > bigcat
+#!/bin/bash
+
+JAR="\$HOME/.m2/repository/sc/fiji/bigcat/0.0.4-SNAPSHOT/bigcat-0.0.4-SNAPSHOT.jar"
+java \\
+  -Xmx${MEM}g \\
+  -XX:+UseConcMarkSweepGC \\
+  -cp "\$JAR:$(cat cp.txt)" \\
+  bdv.bigcat.BigCat "\$@"
+EOF
 
 chmod a+x bigcat
 rm cp.txt


### PR DESCRIPTION
Executing `./install` on macOS fails on the RAM detection step because `/proc/meminfo` on Linux is provided by a kernel-specific _procfs_.
This PR adds total physical RAM detection for macOS, and also assumes 4 GB on unknown platforms.

Closes #106, and possibly affects #110.